### PR TITLE
Jinliang/fsdp no shard vit

### DIFF
--- a/examples/mimo/model_providers/kimi_k25/model.py
+++ b/examples/mimo/model_providers/kimi_k25/model.py
@@ -81,6 +81,18 @@ class KimiK25VLModel(MegatronModule):
             for p in self.mm_projector.parameters():
                 p.requires_grad = False
 
+        # Mark frozen vision modules as non-shardable so FSDP keeps them
+        # replicated, avoiding unnecessary all-gather/reshard communication.
+        try:
+            from megatron.core.distributed.fsdp.src.megatron_fsdp import fsdp_no_shard
+
+            if freeze_vision_model and hasattr(self, "vision_tower"):
+                fsdp_no_shard(self.vision_tower)
+            if freeze_vision_projection and hasattr(self, "mm_projector"):
+                fsdp_no_shard(self.mm_projector)
+        except ImportError:
+            pass
+
     # ------------------------------------------------------------------
     # Vision init
     # ------------------------------------------------------------------

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/__init__.py
@@ -15,6 +15,7 @@
 from .distributed_data_parallel_config import DistributedDataParallelConfig
 from .fully_shard import fully_shard, fully_shard_model, fully_shard_optimizer
 from .megatron_fsdp import MegatronFSDP
+from .param_and_grad_buffer import fsdp_no_shard
 from .package_info import (
     __contact_emails__,
     __contact_names__,
@@ -34,6 +35,7 @@ __all__ = [
     "DistributedDataParallelConfig",
     "MegatronFSDP",
     "FSDPDistributedIndex",
+    "fsdp_no_shard",
     "fully_shard",
     "fully_shard_model",
     "fully_shard_optimizer",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -981,6 +981,7 @@ class MegatronFSDP(torch.nn.Module):
             # Skip modules (and their descendants) whose params are all no_shard.
             # These are replicated and never need all-gather/reshard hooks.
             if any(is_submodule(module, ns_mod) for ns_mod in no_shard_modules):
+                logger.debug(f"[fsdp_no_shard] skip descendant: {name}")
                 continue
             if _module_params_all_no_shard(module):
                 no_shard_modules.append(module)
@@ -1044,6 +1045,13 @@ class MegatronFSDP(torch.nn.Module):
                         lambda p: _process_post_backward_gradients([p])
                     )
                 )
+
+        if no_shard_modules:
+            logger.info(
+                f"[fsdp_no_shard] Skipped FSDP hooks for {len(no_shard_modules)} "
+                f"no_shard root module(s): "
+                f"{[m._get_name() for m in no_shard_modules]}"
+            )
 
         # Register root module pre- and post-backward hooks in cases where the
         # forward function of root module is not called, but rather the forward

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -18,7 +18,7 @@ import logging
 from contextlib import contextmanager
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Tuple
-from megatron.core.utils import nvtx_decorator
+
 import torch
 import torch.nn as nn
 from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten
@@ -677,7 +677,6 @@ class MegatronFSDP(torch.nn.Module):
                 self._params_require_handle_grad.discard(param)
 
         @torch.compiler.disable
-        @nvtx_decorator()
         def _pre_forward_param_unshard(
             module: nn.Module, args: Tuple[Any, ...], kwargs: Dict[str, Any]
         ):
@@ -806,7 +805,6 @@ class MegatronFSDP(torch.nn.Module):
                 self.finish_grad_sync()
 
         @torch.compiler.disable
-        @nvtx_decorator()
         def _pre_backward_param_unshard(module: nn.Module, *unused):
             """
             Sub-module pre-backward hook to all-gather the module parameters
@@ -870,7 +868,6 @@ class MegatronFSDP(torch.nn.Module):
             torch.autograd.Variable._execution_engine.queue_callback(_root_post_backward)
 
         @torch.compiler.disable
-        @nvtx_decorator()
         def _post_forward(module: nn.Module, input: Any, output: Any):
             # When composed with module-hook-based activation recomputation, the
             # post-backward hook is responsible for resharding the module parameters
@@ -895,7 +892,6 @@ class MegatronFSDP(torch.nn.Module):
             return output
 
         @torch.compiler.disable
-        @nvtx_decorator()
         def _release_module_fp8_transpose_cache(module: nn.Module, *unused):
             release_params_fp8_transpose_cache(module.parameters(recurse=False))
 
@@ -954,8 +950,6 @@ class MegatronFSDP(torch.nn.Module):
             are kept replicated and never need all-gathering.
             """
             if self.ddp_config.data_parallel_sharding_strategy != "no_shard":
-                if _module_params_all_no_shard(module):
-                    return
                 self.forward_pre_hooks[f"{module._get_name()} parameter unshard"] = (
                     module.register_forward_pre_hook(
                         _pre_forward_param_unshard, prepend=True, with_kwargs=True
@@ -969,8 +963,6 @@ class MegatronFSDP(torch.nn.Module):
             hook to the output tensor(s) of a module during a post-forward hook.
             Skip for modules whose parameters are all marked _fsdp_no_shard.
             """
-            if _module_params_all_no_shard(module):
-                return
             self.backward_pre_hooks[f"all-gather {module._get_name()} parameters"] = (
                 create_custom_backward_hook(module, _pre_backward_param_unshard)
             )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -18,7 +18,7 @@ import logging
 from contextlib import contextmanager
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Tuple
-
+from megatron.core.utils import nvtx_decorator
 import torch
 import torch.nn as nn
 from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten
@@ -677,6 +677,7 @@ class MegatronFSDP(torch.nn.Module):
                 self._params_require_handle_grad.discard(param)
 
         @torch.compiler.disable
+        @nvtx_decorator()
         def _pre_forward_param_unshard(
             module: nn.Module, args: Tuple[Any, ...], kwargs: Dict[str, Any]
         ):
@@ -805,6 +806,7 @@ class MegatronFSDP(torch.nn.Module):
                 self.finish_grad_sync()
 
         @torch.compiler.disable
+        @nvtx_decorator()
         def _pre_backward_param_unshard(module: nn.Module, *unused):
             """
             Sub-module pre-backward hook to all-gather the module parameters
@@ -868,6 +870,7 @@ class MegatronFSDP(torch.nn.Module):
             torch.autograd.Variable._execution_engine.queue_callback(_root_post_backward)
 
         @torch.compiler.disable
+        @nvtx_decorator()
         def _post_forward(module: nn.Module, input: Any, output: Any):
             # When composed with module-hook-based activation recomputation, the
             # post-backward hook is responsible for resharding the module parameters
@@ -892,6 +895,7 @@ class MegatronFSDP(torch.nn.Module):
             return output
 
         @torch.compiler.disable
+        @nvtx_decorator()
         def _release_module_fp8_transpose_cache(module: nn.Module, *unused):
             release_params_fp8_transpose_cache(module.parameters(recurse=False))
 
@@ -929,13 +933,29 @@ class MegatronFSDP(torch.nn.Module):
             # on the output tensor(s).
             return module.register_forward_hook(forward_hook)
 
+        def _module_params_all_no_shard(module):
+            """Check if all parameters of a module (including children) are _fsdp_no_shard.
+
+            Returns True if every parameter under this module is marked no_shard,
+            meaning no all-gather/reshard hooks are needed for this module or its
+            descendants.  Returns False if there are no parameters.
+            """
+            params = list(module.parameters())
+            return len(params) > 0 and all(
+                getattr(p, "_fsdp_no_shard", False) for p in params
+            )
+
         def _register_pre_forward_param_unshard_hook(module):
             """
             Register the forward pre-hook to unshard parameters before the forward pass.
             If we are not sharding anything, we do not have a model weight buffer and thus
             have nothing to all-gather / un-shard.
+            Skip for modules whose parameters are all marked _fsdp_no_shard, since they
+            are kept replicated and never need all-gathering.
             """
             if self.ddp_config.data_parallel_sharding_strategy != "no_shard":
+                if _module_params_all_no_shard(module):
+                    return
                 self.forward_pre_hooks[f"{module._get_name()} parameter unshard"] = (
                     module.register_forward_pre_hook(
                         _pre_forward_param_unshard, prepend=True, with_kwargs=True
@@ -947,13 +967,25 @@ class MegatronFSDP(torch.nn.Module):
             Register the backward pre-hook to unshard FSDP unit module parameters
             immediately before the backward pass via attaching a gradient-triggered
             hook to the output tensor(s) of a module during a post-forward hook.
+            Skip for modules whose parameters are all marked _fsdp_no_shard.
             """
+            if _module_params_all_no_shard(module):
+                return
             self.backward_pre_hooks[f"all-gather {module._get_name()} parameters"] = (
                 create_custom_backward_hook(module, _pre_backward_param_unshard)
             )
 
         fsdp_modules = []
+        no_shard_modules = []
         for name, module in root_module.named_modules():
+            # Skip modules (and their descendants) whose params are all no_shard.
+            # These are replicated and never need all-gather/reshard hooks.
+            if any(is_submodule(module, ns_mod) for ns_mod in no_shard_modules):
+                continue
+            if _module_params_all_no_shard(module):
+                no_shard_modules.append(module)
+                continue
+
             if self.enable_fine_grained_param_gather_hook:
                 _register_pre_forward_param_unshard_hook(module)
                 _register_pre_backward_param_unshard_hook(module)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -1259,6 +1259,7 @@ class ParameterGroup:
     is_expert_param: bool = False
     requires_grad: Optional[bool] = None
     fsdp_unit_id: Optional[int] = None
+    fsdp_no_shard: bool = False
     chunk_size_factor: int = 1
     model_weight_buffer: Optional[DataParallelBuffer] = None
     transpose_weight_buffer: Optional[DataParallelBuffer] = None
@@ -1266,6 +1267,40 @@ class ParameterGroup:
     main_grad_buffer: Optional[DataParallelBuffer] = None
     hsdp_wbuf: Optional[DataParallelBuffer] = None
     hsdp_gbuf: Optional[DataParallelBuffer] = None
+
+
+def fsdp_no_shard(module_or_param: "torch.nn.Module | torch.nn.Parameter"):
+    """Mark a module or parameter so that FSDP keeps it replicated (not sharded).
+
+    This is useful for small or frozen sub-modules (e.g. a frozen vision encoder)
+    where sharding would add unnecessary all-gather / reshard communication.
+
+    Args:
+        module_or_param: An ``nn.Module`` (all its parameters are marked) or a
+            single ``nn.Parameter``.
+
+    Returns:
+        The input ``module_or_param`` (for convenient chaining).
+
+    Example::
+
+        from megatron.core.distributed.fsdp.src.megatron_fsdp import fsdp_no_shard
+
+        model = MyModel()
+        fsdp_no_shard(model.vision_tower)   # mark entire sub-module
+        fsdp_no_shard(model.mm_projector)   # mark another sub-module
+        # … then wrap the whole model with MegatronFSDP / FullyShardedDataParallel
+    """
+    if isinstance(module_or_param, torch.nn.Module):
+        for param in module_or_param.parameters():
+            param._fsdp_no_shard = True
+    elif isinstance(module_or_param, torch.nn.Parameter):
+        module_or_param._fsdp_no_shard = True
+    else:
+        raise TypeError(
+            f"Expected nn.Module or nn.Parameter, got {type(module_or_param)}"
+        )
+    return module_or_param
 
 
 def _get_parameter_groups(
@@ -1339,6 +1374,7 @@ def _get_parameter_groups(
             is_expert_param=is_expert_parameter(name, param),
             requires_grad=param.requires_grad,
             fsdp_unit_id=None,
+            fsdp_no_shard=getattr(param, "_fsdp_no_shard", False),
         )
 
         # For all the new FSDP unit parameters collected, assign an ID number
@@ -1375,7 +1411,7 @@ def _get_parameter_groups(
         basic_attrs = {
             key: value
             for key, value in group.__dict__.items()
-            if key in ["dtype", "is_expert_param", "requires_grad", "fsdp_unit_id"]
+            if key in ["dtype", "is_expert_param", "requires_grad", "fsdp_unit_id", "fsdp_no_shard"]
         }
         for param in group.params:
             if _does_param_require_new_bucket(param):
@@ -1446,6 +1482,7 @@ def _get_parameter_groups(
                     is_expert_param=group.is_expert_param,
                     requires_grad=group.requires_grad,
                     fsdp_unit_id=group.fsdp_unit_id,
+                    fsdp_no_shard=group.fsdp_no_shard,
                     chunk_size_factor=chunk_size_factor,
                 )
             )
@@ -1824,9 +1861,11 @@ class ParamAndGradBuffer:
             total_comm_bytes += group_comm
 
             # One-line summary for the group
+            no_shard_tag = " no_shard" if group.fsdp_no_shard else ""
             log_lines.append(
                 f"[FSDP_UNIT {group.fsdp_unit_id}] Group {idx}: elems={numel} dtype={group.dtype} "
                 f"bufs={','.join(buf_flags) or 'None'} pad={_bytes_to_mb(group_padded)}"
+                f"{no_shard_tag}"
             )
             # List parameters below
             for param in group.params:
@@ -1969,12 +2008,19 @@ class ParamAndGradBuffer:
             )
 
             # Initialize the model weight buffer from bucket parameters.
+            # Parameters marked with _fsdp_no_shard=True are kept replicated
+            # (is_data_distributed=False) to avoid unnecessary all-gather/reshard
+            # overhead for small or non-trainable modules (e.g. frozen vision encoders).
+            should_shard_model_weights = (
+                is_model_weight_buffer_distributed
+                and model_wbuf_dp_group.size() > 1
+                and not group.fsdp_no_shard
+            )
             if data_parallel_sharding_strategy != "no_shard":
                 group.model_weight_buffer = DataParallelBuffer(
                     self.ddp_config,
                     group.params,
-                    is_data_distributed=is_model_weight_buffer_distributed
-                    and model_wbuf_dp_group.size() > 1,
+                    is_data_distributed=should_shard_model_weights,
                     dtype=param_dtype,
                     device=self.device,
                     data_parallel_group=model_wbuf_dp_group,
@@ -1989,8 +2035,7 @@ class ParamAndGradBuffer:
                     group.transpose_weight_buffer = DataParallelBuffer(
                         self.ddp_config,
                         group.params,
-                        is_data_distributed=is_model_weight_buffer_distributed
-                        and main_buf_dp_group.size() > 1,
+                        is_data_distributed=should_shard_model_weights,
                         dtype=param_dtype,
                         device=self.device,
                         data_parallel_group=main_buf_dp_group,
@@ -3618,6 +3663,9 @@ class AllGatherPipeline:
             # Replace the parameter all-gather event with coalescing event.
             for bucket_id in buckets:
                 bucket_key = self.get_bucket_key(bucket_id, bwd)
+                if bucket_key not in self.param_gather_event_map:
+                    # Bucket was not all-gathered (e.g. replicated/frozen params).
+                    continue
                 _, mark_bucket_ready_to_use = self.param_gather_event_map[bucket_key]
                 self.param_gather_event_map[bucket_key] = (
                     coalescing_event,
@@ -3735,6 +3783,12 @@ class AllGatherPipeline:
         self.recycle_unused_buckets()
         # Allocate an empty bucket to store the module weights.
         bucket = wbuf.fetch_bucket(set_param_data=True)
+
+        if not wbuf.is_data_distributed:
+            # Buffer is replicated (e.g. frozen params), no all-gather needed.
+            self.bucket_status[bucket_key] = BucketStatus.READY_TO_USE
+            return
+
         # All-gather the module weights in each buffer shard into the allocated bucket.
         # Now each rank will have a copy of this FSDP unit module's weights.
         param_gather_event = torch.distributed.all_gather_into_tensor(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/param_and_grad_buffer.py
@@ -1291,15 +1291,8 @@ def fsdp_no_shard(module_or_param: "torch.nn.Module | torch.nn.Parameter"):
         fsdp_no_shard(model.mm_projector)   # mark another sub-module
         # … then wrap the whole model with MegatronFSDP / FullyShardedDataParallel
     """
-    if isinstance(module_or_param, torch.nn.Module):
-        for param in module_or_param.parameters():
-            param._fsdp_no_shard = True
-    elif isinstance(module_or_param, torch.nn.Parameter):
-        module_or_param._fsdp_no_shard = True
-    else:
-        raise TypeError(
-            f"Expected nn.Module or nn.Parameter, got {type(module_or_param)}"
-        )
+    for param in module_or_param.parameters():
+        param._fsdp_no_shard = True
     return module_or_param
 
 
@@ -2480,7 +2473,9 @@ class ParamAndGradBuffer:
 
             new_param.requires_grad_(old_param.requires_grad)
 
-            for tp_attr in ["_mcore_tp", "_tp_partition_dim", "_tp_duplicated"]:
+            for tp_attr in [
+                "_mcore_tp", "_tp_partition_dim", "_tp_duplicated", "_fsdp_no_shard",
+            ]:
                 if getattr(old_param, tp_attr, None) is not None:
                     setattr(new_param, tp_attr, getattr(old_param, tp_attr))
 
@@ -2635,6 +2630,7 @@ class ParamAndGradBuffer:
                             "_mcore_tp",
                             "_tp_duplicated",
                             "_tp_partition_dim",
+                            "_fsdp_no_shard",
                         ]:
                             if hasattr(orig_param, attr_name):
                                 setattr(param, attr_name, getattr(orig_param, attr_name))


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @megatron-oncall.

## Contribution process

```mermaid
flowchart LR
    A[Pre-checks] --> B[PR Tests]
    subgraph Code Review/Approval
        C1[Expert Review] --> C2[Final Review]
    end
    B --> C1
    C2 --> D[Merge]
```

### Pre-checks

- [ ] I want this PR in a versioned release and have added the appropriate Milestone (e.g., `Core 0.8`)
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

The following process is enforced via the CODEOWNERS file for changes into `megatron/core`. For changes outside of `megatron/core`, it is up to the PR author whether or not to tag the Final Reviewer team.

<details>
<summary>For MRs into `main` branch</summary>

Feel free to message or comment the @megatron-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

#### (Step 1): Add PR label `Expert Review`

#### (Step 2): Collect the expert reviewers reviews

1. Attach the `Expert Review` label when your PR is ready for review.
2. GitHub auto-assigns expert reviewers based on your changes. They will get notified and pick up your PR soon.

:warning: Only proceed to the next step once all reviewers have approved, merge-conflict are resolved and the CI is passing.  
Final Review might get declined if these requirements are not fulfilled.

#### (Step 3): Final Review

1. Add `Final Review` label
2. GitHub auto-assigns final reviewers based on your changes. They will get notified and pick up your PR soon.

#### (Optional Step 4): Cherry-pick into release branch

If this PR also needs to be merged into `core_r*` release branches, after this PR has been merged, select `Cherry-pick` to open a new PR into the release branch.

</details>

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

### Merging your PR

Any member of [core-adlr](https://github.com/orgs/teams/NVIDIA/core-adlr) and [`core-nemo`](https://github.com/orgs/teams/NVIDIA/core-nemo) will be able to merge your PR.

## Summary by Sourcery

Introduce an opt-in mechanism to keep selected parameters/modules replicated under FSDP and integrate it into buffer initialization, hook registration, and example models to avoid unnecessary all-gather/reshard for frozen components.

New Features:
- Add an fsdp_no_shard helper and flag to mark parameters or modules that should remain replicated instead of being sharded in FSDP.
- Expose fsdp_no_shard from the megatron_fsdp package and apply it to frozen vision components in the Kimi K25 example model.

Enhancements:
- Propagate the fsdp_no_shard attribute through parameter regrouping, cloning, and logging so FSDP bucket metadata and debug output reflect non-sharded groups.
- Update FSDP buffer initialization and async bucket gather logic to skip data distribution and all-gather for non-sharded parameter groups, and guard hook coalescing for buckets that were never gathered.
- Skip registration of unshard/all-gather hooks for modules whose parameters are all marked no_shard and log the set of such modules at startup.
- Decorate key FSDP pre/post-forward and pre-backward hooks with nvtx_decorator for improved profiling.