### PR TITLE
Fix Megatron-FSDP GDN optimizer checkpoint metadata for FSDP DTensor

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
@@ -244,11 +244,19 @@ def preprocess_state_dict_for_uneven_dtensor(state_dict: dict) -> dict:
     visit_dtensor = filter_unflattened_state_dict(
         state_dict, visit_condition=lambda x: isinstance(x, DTensor)
     )
+
+    def _has_explicit_chunk_metadata(dtensor: DTensor) -> bool:
+        local_tensor = dtensor._local_tensor
+        marker = "_megatron_fsdp_explicit_chunk_metadata"
+        return getattr(dtensor, marker, False) or getattr(local_tensor, marker, False)
+
     # Sort the keys, since some state dictionaries are mocked
     # and extended to include empty global keys.
     for key_chain in sorted(visit_dtensor):
         # Get the DTensor at the key chain
         dtensor = get_unflattened_state_dict(state_dict, key_chain)
+        if _has_explicit_chunk_metadata(dtensor):
+            continue
         update_uneven_dtensor_chunk_metadata(dtensor)
     return state_dict
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/uneven_dtensor.py
@@ -25,6 +25,68 @@ from torch.distributed.checkpoint.metadata import (
 from torch.distributed.checkpoint.planner import TensorWriteData, WriteItem, WriteItemType
 from torch.distributed.tensor.placement_types import Replicate, Shard, _StridedShard
 
+_EXPLICIT_CHUNK_METADATA_MARKER = "_megatron_fsdp_explicit_chunk_metadata"
+
+
+def _make_dcp_chunk_hooks(chunk_metadata: ChunkStorageMetadata):
+    def _chunk_list():
+        return [chunk_metadata]
+
+    def _write_items(fqn: str, dtensor: DTensor) -> List[WriteItem]:
+        if dtensor.to_local().numel() == 0:
+            return []
+
+        return [
+            WriteItem(
+                type=WriteItemType.SHARD,
+                index=MetadataIndex(fqn, chunk_metadata.offsets),
+                tensor_data=TensorWriteData(
+                    chunk=chunk_metadata,
+                    properties=TensorProperties.create_from_tensor(dtensor.to_local()),
+                    size=dtensor.size(),
+                ),
+            )
+        ]
+
+    return _chunk_list, _write_items
+
+
+def _set_dtensor_chunk_metadata(
+    dtensor: DTensor, chunk_metadata: ChunkStorageMetadata, explicit: bool = False
+) -> None:
+    """Attach DCP chunk metadata hooks to both DTensor and its local tensor."""
+    chunk_list_hook, write_items_hook = _make_dcp_chunk_hooks(chunk_metadata)
+    dtensor.__create_chunk_list__ = chunk_list_hook
+    dtensor.__create_write_items__ = write_items_hook
+    dtensor._local_tensor.__create_chunk_list__ = chunk_list_hook
+    dtensor._local_tensor.__create_write_items__ = write_items_hook
+    if explicit:
+        dtensor._megatron_fsdp_explicit_chunk_metadata = True
+        dtensor._local_tensor._megatron_fsdp_explicit_chunk_metadata = True
+
+
+def set_explicit_dtensor_chunk_metadata(dtensor: DTensor, offsets, sizes) -> None:
+    """Attach caller-provided DCP chunk metadata without rank-order collectives."""
+    assert all(
+        0 <= offset and offset + size <= dtensor.shape[dim]
+        for dim, (offset, size) in enumerate(zip(offsets, sizes))
+    ), (
+        "[Megatron-FSDP] Explicit DTensor chunk metadata is invalid.\n"
+        f"offsets={tuple(offsets)}, sizes={tuple(sizes)}, global_shape={dtensor.shape}, "
+    )
+    _set_dtensor_chunk_metadata(
+        dtensor,
+        ChunkStorageMetadata(offsets=tuple(offsets), sizes=tuple(sizes)),
+        explicit=True,
+    )
+
+
+def has_explicit_dtensor_chunk_metadata(dtensor: DTensor) -> bool:
+    local_tensor = dtensor._local_tensor
+    return getattr(dtensor, _EXPLICIT_CHUNK_METADATA_MARKER, False) or getattr(
+        local_tensor, _EXPLICIT_CHUNK_METADATA_MARKER, False
+    )
+
 
 def gather_and_compute_chunk_metadata(dtensor: DTensor) -> ChunkStorageMetadata:
     """
@@ -100,29 +162,6 @@ def update_uneven_dtensor_chunk_metadata(dtensor: DTensor) -> dict:
     and write items closures for saving and loading.
     """
 
-    def _chunk_list_closure(chunk_meta):
-        return lambda: chunk_meta
-
-    def _write_items_closure(uneven_chunk_meta):
-        def _write_items(fqn: str, tensor: DTensor) -> List[WriteItem]:
-            if tensor.to_local().numel() == 0:
-                # If the tensor is empty, return an empty list
-                return []
-
-            return [
-                WriteItem(
-                    type=WriteItemType.SHARD,
-                    index=MetadataIndex(fqn, uneven_chunk_meta.offsets),
-                    tensor_data=TensorWriteData(
-                        chunk=uneven_chunk_meta,
-                        properties=TensorProperties.create_from_tensor(tensor.to_local()),
-                        size=tensor.size(),
-                    ),
-                )
-            ]
-
-        return _write_items
-
     # Get uneven chunk metadata for the DTensor
     # TODO: Optimize gather_and_compute_chunk_metadata synchronization:
     # 1. Add pre-check validation to verify tensor shape consistency
@@ -130,10 +169,7 @@ def update_uneven_dtensor_chunk_metadata(dtensor: DTensor) -> dict:
     # 2. Implement batched barrier using grouped collectives
     #    to amortize synchronization overhead
     uneven_chunk_meta = gather_and_compute_chunk_metadata(dtensor)
-
-    # Set the chunk list and write items closure for the DTensor
-    dtensor._local_tensor.__create_chunk_list__ = _chunk_list_closure([uneven_chunk_meta])
-    dtensor._local_tensor.__create_write_items__ = _write_items_closure(uneven_chunk_meta)
+    _set_dtensor_chunk_metadata(dtensor, uneven_chunk_meta)
 
 
 def validate_uneven_dtensor(dtensor: DTensor) -> None:
@@ -164,12 +200,9 @@ def validate_uneven_dtensor(dtensor: DTensor) -> None:
             for (dim, (offset, size)) in enumerate(zip(chunk_meta.offsets, chunk_meta.sizes))
         ]
     ), (
-        "[Megatron-FSDP] DTensor chunk metadata is invalid. "
-        f"Offsets: {chunk_meta.offsets}, "
-        f"Sizes: {chunk_meta.sizes}, "
-        f"Global shape: {dtensor.shape}, "
-        f"Local shape: {dtensor.to_local().shape}, "
-        f"Device mesh: {dtensor.device_mesh}."
+        "[Megatron-FSDP] DTensor chunk metadata is invalid.\n"
+        f"offsets={chunk_meta.offsets}, sizes={chunk_meta.sizes}, global_shape={dtensor.shape}, "
+        f"local_shape={dtensor.to_local().shape}"
     )
 
     # Check that all boundaries (start and end) are touched.
@@ -245,17 +278,12 @@ def preprocess_state_dict_for_uneven_dtensor(state_dict: dict) -> dict:
         state_dict, visit_condition=lambda x: isinstance(x, DTensor)
     )
 
-    def _has_explicit_chunk_metadata(dtensor: DTensor) -> bool:
-        local_tensor = dtensor._local_tensor
-        marker = "_megatron_fsdp_explicit_chunk_metadata"
-        return getattr(dtensor, marker, False) or getattr(local_tensor, marker, False)
-
     # Sort the keys, since some state dictionaries are mocked
     # and extended to include empty global keys.
     for key_chain in sorted(visit_dtensor):
         # Get the DTensor at the key chain
         dtensor = get_unflattened_state_dict(state_dict, key_chain)
-        if _has_explicit_chunk_metadata(dtensor):
+        if has_explicit_dtensor_chunk_metadata(dtensor):
             continue
         update_uneven_dtensor_chunk_metadata(dtensor)
     return state_dict

--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -401,7 +401,9 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         if not self.param_update_in_fp32:
             return
         for param, v in self.state.items():
-            fp32_param = self.param_to_fp32_param[param]
+            fp32_param = self.param_to_fp32_param.get(param)
+            if fp32_param is None:
+                continue
             master_param = v.get("master_param")
             if master_param is None:
                 master_param = _to_local_if_dtensor(param)

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1741,6 +1741,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     (fsdp_local_numel,), dtype=expected_tensor_state_dtypes[key], device="cpu"
                 )
 
+            if isinstance(value, DTensor) and key in expected_tensor_state_dtypes:
+                value = value.to_local().contiguous()
+
             if (
                 isinstance(value, torch.Tensor)
                 and not isinstance(value, DTensor)

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1622,6 +1622,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         # each local shard as replicated data. Its fp32 master params duplicate
         # Megatron-FSDP's model-state main weights, so they are intentionally not
         # stored in the optimizer state.
+        param_name_to_param = {
+            self._param_name(param): param
+            for group in self.optimizer.param_groups
+            for param in group["params"]
+        }
+
         if isinstance(self.optimizer, HybridDeviceOptimizer):
             packed_state = self._pack_hybrid_optimizer_fsdp_state_dict()
         else:
@@ -1629,9 +1635,44 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 (self._param_name(k) if isinstance(k, torch.Tensor) else k): v
                 for k, v in self.state.items()
             }
+        self._set_fsdp_optimizer_state_chunk_metadata(packed_state, param_name_to_param)
 
         state_dict = {"state": packed_state, "param_to_group_meta": param_to_group_meta}
         return state_dict
+
+    def _get_flat_fsdp_dtensor_tp_offset(
+        self, param: torch.nn.Parameter, param_name: str, is_expert_param: bool
+    ) -> int:
+        """Return the flattened TP offset for a parameter-local optimizer state."""
+        if getattr(param, "_tensor_parallel_mode", None) not in ("column", "row"):
+            return 0
+
+        dist_index = param.megatron_fsdp_dist_index
+        tp_mesh = dist_index.get_submesh([dist_index.tp_dim], is_expert_parallel=is_expert_param)
+        tp_world_size = tp_mesh.mesh.numel()
+        assert param.numel() % tp_world_size == 0, (
+            f"FSDP optimizer TP state for {param_name} has numel={param.numel()} "
+            f"not divisible by TP={tp_world_size}."
+        )
+        tp_rank = torch.distributed.get_rank(tp_mesh.get_group())
+        return tp_rank * (param.numel() // tp_world_size)
+
+    def _set_fsdp_optimizer_state_chunk_metadata(
+        self, packed_state: dict[str, Any], param_name_to_param: dict[str, torch.nn.Parameter]
+    ) -> None:
+        """Attach non-collective DCP metadata to flat optimizer-state DTensors."""
+        for param_name, param_state in packed_state.items():
+            if param_name not in param_name_to_param or not isinstance(param_state, dict):
+                continue
+
+            param = param_name_to_param[param_name]
+            is_expert_param = "mlp.experts" in param_name
+            tp_offset = self._get_flat_fsdp_dtensor_tp_offset(param, param_name, is_expert_param)
+            for value in param_state.values():
+                if isinstance(value, DTensor) and value.dim() == 1:
+                    self._set_flat_fsdp_dtensor_chunk_metadata(
+                        value, param.megatron_fsdp_slice, tp_offset=tp_offset
+                    )
 
     def _pack_hybrid_optimizer_fsdp_state_dict(self) -> dict[str, Any]:
         """Pack HybridDeviceOptimizer state in a deterministic cross-rank order."""
@@ -1722,6 +1763,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 )
                 flat_param = torch.empty(param.numel(), device="meta")
                 try:
+                    tp_offset = self._get_flat_fsdp_dtensor_tp_offset(
+                        param, param_name, is_expert_param
+                    )
+
                     value = make_fsdp_dtensor(
                         value.data.view(-1),
                         flat_param,
@@ -1731,7 +1776,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         update_uneven_dtensor_chunk_meta=False,
                     )
                     self._set_flat_fsdp_dtensor_chunk_metadata(
-                        value, param.megatron_fsdp_slice
+                        value, param.megatron_fsdp_slice, tp_offset=tp_offset
                     )
                 except Exception as exc:
                     rank = torch.distributed.get_rank()
@@ -1744,12 +1789,13 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         return packed_state
 
     @staticmethod
-    def _set_flat_fsdp_dtensor_chunk_metadata(tensor: DTensor, fsdp_slice: slice) -> None:
+    def _set_flat_fsdp_dtensor_chunk_metadata(
+        tensor: DTensor, fsdp_slice: slice, tp_offset: int = 0
+    ) -> None:
         """Attach DCP chunk metadata for a flat FSDP-local shard without collectives."""
         local_numel = fsdp_slice.stop - fsdp_slice.start
         chunk_meta = ChunkStorageMetadata(
-            offsets=(fsdp_slice.start,),
-            sizes=(local_numel,),
+            offsets=(tp_offset + fsdp_slice.start,), sizes=(local_numel,)
         )
 
         def _chunk_list_closure(chunk_metadata):
@@ -1774,8 +1820,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
             return _write_items
 
+        tensor.__create_chunk_list__ = _chunk_list_closure(chunk_meta)
+        tensor.__create_write_items__ = _write_items_closure(chunk_meta)
+        tensor._megatron_fsdp_explicit_chunk_metadata = True
         tensor._local_tensor.__create_chunk_list__ = _chunk_list_closure(chunk_meta)
         tensor._local_tensor.__create_write_items__ = _write_items_closure(chunk_meta)
+        tensor._local_tensor._megatron_fsdp_explicit_chunk_metadata = True
 
     def sharded_param_state_dp_zero(
         self,

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -38,25 +38,17 @@ from megatron.core.optimizer.cpu_offloading import HybridDeviceOptimizer
 
 try:
     from torch.distributed._tensor import DTensor
-    from torch.distributed.checkpoint.metadata import (
-        ChunkStorageMetadata,
-        MetadataIndex,
-        TensorProperties,
-    )
-    from torch.distributed.checkpoint.planner import TensorWriteData, WriteItem, WriteItemType
 
     from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
         make_fsdp_dtensor,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        set_explicit_dtensor_chunk_metadata,
+    )
 except ImportError:
-    ChunkStorageMetadata = None
     DTensor = None
-    MetadataIndex = None
-    TensorProperties = None
-    TensorWriteData = None
-    WriteItem = None
-    WriteItemType = None
     make_fsdp_dtensor = None
+    set_explicit_dtensor_chunk_metadata = None
 
 from .. import tensor_parallel
 from ..config_logger import has_config_logger_enabled, log_config_to_disk
@@ -1670,8 +1662,11 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             tp_offset = self._get_flat_fsdp_dtensor_tp_offset(param, param_name, is_expert_param)
             for value in param_state.values():
                 if isinstance(value, DTensor) and value.dim() == 1:
-                    self._set_flat_fsdp_dtensor_chunk_metadata(
-                        value, param.megatron_fsdp_slice, tp_offset=tp_offset
+                    fsdp_slice = param.megatron_fsdp_slice
+                    set_explicit_dtensor_chunk_metadata(
+                        value,
+                        offsets=(tp_offset + fsdp_slice.start,),
+                        sizes=(fsdp_slice.stop - fsdp_slice.start,),
                     )
 
     def _pack_hybrid_optimizer_fsdp_state_dict(self) -> dict[str, Any]:
@@ -1715,12 +1710,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         if (
             make_fsdp_dtensor is None
             or DTensor is None
-            or ChunkStorageMetadata is None
-            or MetadataIndex is None
-            or TensorProperties is None
-            or TensorWriteData is None
-            or WriteItem is None
-            or WriteItemType is None
+            or set_explicit_dtensor_chunk_metadata is None
         ):
             raise RuntimeError("Megatron-FSDP DTensor support is required for fsdp_dtensor.")
 
@@ -1763,10 +1753,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 )
                 flat_param = torch.empty(param.numel(), device="meta")
                 try:
-                    tp_offset = self._get_flat_fsdp_dtensor_tp_offset(
-                        param, param_name, is_expert_param
-                    )
-
                     value = make_fsdp_dtensor(
                         value.data.view(-1),
                         flat_param,
@@ -1774,9 +1760,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         is_expert_param=is_expert_param,
                         run_check=False,
                         update_uneven_dtensor_chunk_meta=False,
-                    )
-                    self._set_flat_fsdp_dtensor_chunk_metadata(
-                        value, param.megatron_fsdp_slice, tp_offset=tp_offset
                     )
                 except Exception as exc:
                     rank = torch.distributed.get_rank()
@@ -1787,45 +1770,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             packed_state[key] = value
 
         return packed_state
-
-    @staticmethod
-    def _set_flat_fsdp_dtensor_chunk_metadata(
-        tensor: DTensor, fsdp_slice: slice, tp_offset: int = 0
-    ) -> None:
-        """Attach DCP chunk metadata for a flat FSDP-local shard without collectives."""
-        local_numel = fsdp_slice.stop - fsdp_slice.start
-        chunk_meta = ChunkStorageMetadata(
-            offsets=(tp_offset + fsdp_slice.start,), sizes=(local_numel,)
-        )
-
-        def _chunk_list_closure(chunk_metadata):
-            return lambda: [chunk_metadata]
-
-        def _write_items_closure(chunk_metadata):
-            def _write_items(fqn: str, dtensor: DTensor) -> list[WriteItem]:
-                if dtensor.to_local().numel() == 0:
-                    return []
-
-                return [
-                    WriteItem(
-                        type=WriteItemType.SHARD,
-                        index=MetadataIndex(fqn, chunk_metadata.offsets),
-                        tensor_data=TensorWriteData(
-                            chunk=chunk_metadata,
-                            properties=TensorProperties.create_from_tensor(dtensor.to_local()),
-                            size=dtensor.size(),
-                        ),
-                    )
-                ]
-
-            return _write_items
-
-        tensor.__create_chunk_list__ = _chunk_list_closure(chunk_meta)
-        tensor.__create_write_items__ = _write_items_closure(chunk_meta)
-        tensor._megatron_fsdp_explicit_chunk_metadata = True
-        tensor._local_tensor.__create_chunk_list__ = _chunk_list_closure(chunk_meta)
-        tensor._local_tensor.__create_write_items__ = _write_items_closure(chunk_meta)
-        tensor._local_tensor._megatron_fsdp_explicit_chunk_metadata = True
 
     def sharded_param_state_dp_zero(
         self,

--- a/megatron/core/transformer/fsdp_dtensor_checkpoint.py
+++ b/megatron/core/transformer/fsdp_dtensor_checkpoint.py
@@ -25,19 +25,14 @@ logger = logging.getLogger(__name__)
 try:
     from torch.distributed import DeviceMesh
     from torch.distributed._tensor import DTensor
-    from torch.distributed.checkpoint.metadata import (
-        ChunkStorageMetadata,
-        MetadataIndex,
-        TensorProperties,
-        TensorStorageMetadata,
-    )
-    from torch.distributed.checkpoint.planner import TensorWriteData, WriteItem, WriteItemType
+    from torch.distributed.checkpoint.metadata import TensorStorageMetadata
     from torch.distributed.tensor.placement_types import Replicate, Shard
 
     from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
         make_fsdp_dtensor,
     )
     from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+        set_explicit_dtensor_chunk_metadata,
         split_dtensor,
         uneven_dtensor_to_full_tensor,
     )
@@ -54,81 +49,6 @@ from megatron.core import parallel_state
 from megatron.core.tensor_parallel.layers import copy_tensor_model_parallel_attributes
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.utils import get_attr_wrapped_model
-
-
-def _set_explicit_dtensor_chunk_metadata(dtensor: "DTensor", offsets, sizes):
-    """Attach DCP chunk metadata for a DTensor whose local shard is not rank-contiguous."""
-    chunk_meta = ChunkStorageMetadata(offsets=tuple(offsets), sizes=tuple(sizes))
-
-    def _chunk_list():
-        return [chunk_meta]
-
-    def _write_items(fqn: str, tensor: "DTensor"):
-        if tensor.to_local().numel() == 0:
-            return []
-        return [
-            WriteItem(
-                type=WriteItemType.SHARD,
-                index=MetadataIndex(fqn, chunk_meta.offsets),
-                tensor_data=TensorWriteData(
-                    chunk=chunk_meta,
-                    properties=TensorProperties.create_from_tensor(tensor.to_local()),
-                    size=tensor.size(),
-                ),
-            )
-        ]
-
-    dtensor.__create_chunk_list__ = _chunk_list
-    dtensor.__create_write_items__ = _write_items
-    dtensor._megatron_fsdp_explicit_chunk_metadata = True
-    dtensor._local_tensor.__create_chunk_list__ = _chunk_list
-    dtensor._local_tensor.__create_write_items__ = _write_items
-    dtensor._local_tensor._megatron_fsdp_explicit_chunk_metadata = True
-
-
-def _validate_explicit_dtensor_chunk_metadata(dtensor: "DTensor", offsets, sizes):
-    """Validate explicitly supplied chunk metadata without recomputing rank-order offsets."""
-    assert all(
-        [
-            0 <= offset and offset + size <= dtensor.shape[dim]
-            for dim, (offset, size) in enumerate(zip(offsets, sizes))
-        ]
-    ), (
-        "[Megatron-FSDP] Explicit DTensor chunk metadata is invalid. "
-        f"Offsets: {tuple(offsets)}, "
-        f"Sizes: {tuple(sizes)}, "
-        f"Global shape: {dtensor.shape}, "
-        f"Local shape: {dtensor.to_local().shape}, "
-        f"Device mesh: {dtensor.device_mesh}."
-    )
-
-    if torch.distributed.is_initialized() and torch.distributed.get_backend() == 'fake':
-        return
-
-    boundary_checks = torch.tensor(
-        [
-            [offset == 0, offset + size == dtensor.shape[dim]]
-            for dim, (offset, size) in enumerate(zip(offsets, sizes))
-        ],
-        dtype=torch.int,
-        device=dtensor.device,
-    )
-
-    for mesh_dim, placement in enumerate(dtensor.placements):
-        if isinstance(placement, Shard):
-            torch.distributed.all_reduce(
-                boundary_checks,
-                op=torch.distributed.ReduceOp.MAX,
-                group=dtensor.device_mesh.get_group(mesh_dim),
-            )
-    assert torch.all(boundary_checks), (
-        "[Megatron-FSDP] Explicit DTensor chunk metadata boundary check failed. "
-        f"Offsets: {tuple(offsets)}, "
-        f"Sizes: {tuple(sizes)}, "
-        f"Global shape: {dtensor.shape}, "
-        f"Local shape: {dtensor.to_local().shape}, "
-        f"Device mesh: {dtensor.device_mesh}."
-    )
 
 
 def get_ep_layer_offset(num_experts: int | None = None) -> int:
@@ -690,8 +610,7 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
                 run_check=False,
                 update_uneven_dtensor_chunk_meta=False,
             )
-            _validate_explicit_dtensor_chunk_metadata(dtensor, chunk_offsets, chunk_sizes)
-            _set_explicit_dtensor_chunk_metadata(dtensor, chunk_offsets, chunk_sizes)
+            set_explicit_dtensor_chunk_metadata(dtensor, chunk_offsets, chunk_sizes)
             results.append(dtensor)
             flat_offset += comp_flat
 

--- a/megatron/core/transformer/fsdp_dtensor_checkpoint.py
+++ b/megatron/core/transformer/fsdp_dtensor_checkpoint.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import math
 import re
 
 import torch
@@ -24,7 +25,13 @@ logger = logging.getLogger(__name__)
 try:
     from torch.distributed import DeviceMesh
     from torch.distributed._tensor import DTensor
-    from torch.distributed.checkpoint.metadata import TensorStorageMetadata
+    from torch.distributed.checkpoint.metadata import (
+        ChunkStorageMetadata,
+        MetadataIndex,
+        TensorProperties,
+        TensorStorageMetadata,
+    )
+    from torch.distributed.checkpoint.planner import TensorWriteData, WriteItem, WriteItemType
     from torch.distributed.tensor.placement_types import Replicate, Shard
 
     from megatron.core.distributed.fsdp.src.megatron_fsdp.param_and_grad_buffer import (
@@ -47,6 +54,81 @@ from megatron.core import parallel_state
 from megatron.core.tensor_parallel.layers import copy_tensor_model_parallel_attributes
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.utils import get_attr_wrapped_model
+
+
+def _set_explicit_dtensor_chunk_metadata(dtensor: "DTensor", offsets, sizes):
+    """Attach DCP chunk metadata for a DTensor whose local shard is not rank-contiguous."""
+    chunk_meta = ChunkStorageMetadata(offsets=tuple(offsets), sizes=tuple(sizes))
+
+    def _chunk_list():
+        return [chunk_meta]
+
+    def _write_items(fqn: str, tensor: "DTensor"):
+        if tensor.to_local().numel() == 0:
+            return []
+        return [
+            WriteItem(
+                type=WriteItemType.SHARD,
+                index=MetadataIndex(fqn, chunk_meta.offsets),
+                tensor_data=TensorWriteData(
+                    chunk=chunk_meta,
+                    properties=TensorProperties.create_from_tensor(tensor.to_local()),
+                    size=tensor.size(),
+                ),
+            )
+        ]
+
+    dtensor.__create_chunk_list__ = _chunk_list
+    dtensor.__create_write_items__ = _write_items
+    dtensor._megatron_fsdp_explicit_chunk_metadata = True
+    dtensor._local_tensor.__create_chunk_list__ = _chunk_list
+    dtensor._local_tensor.__create_write_items__ = _write_items
+    dtensor._local_tensor._megatron_fsdp_explicit_chunk_metadata = True
+
+
+def _validate_explicit_dtensor_chunk_metadata(dtensor: "DTensor", offsets, sizes):
+    """Validate explicitly supplied chunk metadata without recomputing rank-order offsets."""
+    assert all(
+        [
+            0 <= offset and offset + size <= dtensor.shape[dim]
+            for dim, (offset, size) in enumerate(zip(offsets, sizes))
+        ]
+    ), (
+        "[Megatron-FSDP] Explicit DTensor chunk metadata is invalid. "
+        f"Offsets: {tuple(offsets)}, "
+        f"Sizes: {tuple(sizes)}, "
+        f"Global shape: {dtensor.shape}, "
+        f"Local shape: {dtensor.to_local().shape}, "
+        f"Device mesh: {dtensor.device_mesh}."
+    )
+
+    if torch.distributed.is_initialized() and torch.distributed.get_backend() == 'fake':
+        return
+
+    boundary_checks = torch.tensor(
+        [
+            [offset == 0, offset + size == dtensor.shape[dim]]
+            for dim, (offset, size) in enumerate(zip(offsets, sizes))
+        ],
+        dtype=torch.int,
+        device=dtensor.device,
+    )
+
+    for mesh_dim, placement in enumerate(dtensor.placements):
+        if isinstance(placement, Shard):
+            torch.distributed.all_reduce(
+                boundary_checks,
+                op=torch.distributed.ReduceOp.MAX,
+                group=dtensor.device_mesh.get_group(mesh_dim),
+            )
+    assert torch.all(boundary_checks), (
+        "[Megatron-FSDP] Explicit DTensor chunk metadata boundary check failed. "
+        f"Offsets: {tuple(offsets)}, "
+        f"Sizes: {tuple(sizes)}, "
+        f"Global shape: {dtensor.shape}, "
+        f"Local shape: {dtensor.to_local().shape}, "
+        f"Device mesh: {dtensor.device_mesh}."
+    )
 
 
 def get_ep_layer_offset(num_experts: int | None = None) -> int:
@@ -518,7 +600,9 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
         dist_index = dist_param.megatron_fsdp_dist_index
         tp_mesh = dist_index.get_submesh([dist_index.tp_dim], is_expert_parallel=False)
 
-        data_size = dist_param.numel() // tp_mesh.mesh.numel()
+        data_size = dist_param.numel()
+        if is_mcore_tensor_model_parallel(dist_param):
+            data_size //= tp_mesh.mesh.numel()
         elems_per_unit = data_size // total_split
 
         if isinstance(data, DTensor):
@@ -564,15 +648,50 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
             meta_shape[split_dim] = s
             meta = torch.empty(*meta_shape, device="meta")
             copy_tensor_model_parallel_attributes(meta, dist_param)
+            if (
+                tp_mesh.mesh.numel() > 1
+                and split_dim == 0
+                and global_shape[split_dim] == total_split
+                and not is_mcore_tensor_model_parallel(meta)
+            ):
+                # GDN fused parameters are TP-local but do not always carry MCore TP attrs.
+                # Mark the split tensors as column-sharded so DCP plans distinct TP chunks.
+                meta._tensor_parallel_mode = "column"
+
+            trailing_numel = math.prod(meta_shape[split_dim + 1 :])
+            assert trailing_numel > 0, f"Invalid GDN component shape: {meta_shape}"
+            component_start = 0
+            if shard.start != shard.stop:
+                component_start = shard.start - comp_slice.start
+                assert component_start % trailing_numel == 0, (
+                    f"GDN component shard is not aligned with tensor rows: "
+                    f"component_start={component_start}, trailing_numel={trailing_numel}, "
+                    f"meta_shape={meta_shape}, shard={shard}, comp_slice={comp_slice}"
+                )
+                assert comp_data.numel() % trailing_numel == 0, (
+                    f"GDN component shard size is not aligned with tensor rows: "
+                    f"numel={comp_data.numel()}, trailing_numel={trailing_numel}, "
+                    f"meta_shape={meta_shape}, shard={shard}, comp_slice={comp_slice}"
+                )
+
+            chunk_offsets = [0] * len(meta_shape)
+            chunk_offsets[split_dim] = component_start // trailing_numel
+            chunk_sizes = list(comp_data.shape)
+            tp_partition_dim = get_mcore_tensor_parallel_partition_dim(meta)
+            if tp_partition_dim is not None:
+                tp_rank = dist.get_rank(tp_mesh.get_group())
+                chunk_offsets[tp_partition_dim] += tp_rank * meta_shape[tp_partition_dim]
 
             dtensor = make_fsdp_dtensor(
                 comp_data.data,
                 meta,
                 dist_index=dist_index,
                 is_expert_param=False,
-                run_check=True,
-                update_uneven_dtensor_chunk_meta=True,
+                run_check=False,
+                update_uneven_dtensor_chunk_meta=False,
             )
+            _validate_explicit_dtensor_chunk_metadata(dtensor, chunk_offsets, chunk_sizes)
+            _set_explicit_dtensor_chunk_metadata(dtensor, chunk_offsets, chunk_sizes)
             results.append(dtensor)
             flat_offset += comp_flat
 

--- a/megatron/core/transformer/fsdp_dtensor_checkpoint.py
+++ b/megatron/core/transformer/fsdp_dtensor_checkpoint.py
@@ -344,22 +344,47 @@ def handle_swiglu_in_state_dict(model, model_state_dict, optimizer_state_dict):
         copy_tensor_model_parallel_attributes(w_meta, dist_param)
         copy_tensor_model_parallel_attributes(v_meta, dist_param)
 
-        weight_w = make_fsdp_dtensor(
-            weight_w.data,
-            w_meta,
-            dist_index=megatron_fsdp_dist_index,
-            is_expert_param=is_expert_param,
-            run_check=True,
-            update_uneven_dtensor_chunk_meta=True,
-        )
-        weight_v = make_fsdp_dtensor(
-            weight_v.data,
-            v_meta,
-            dist_index=megatron_fsdp_dist_index,
-            is_expert_param=is_expert_param,
-            run_check=True,
-            update_uneven_dtensor_chunk_meta=True,
-        )
+        def make_swiglu_split_dtensor(data, meta, split_slice):
+            meta_shape = list(meta.shape)
+            trailing_numel = math.prod(meta_shape[swiglu_shard_axis + 1 :])
+            assert trailing_numel > 0, f"Invalid SWiGLU component shape: {meta_shape}"
+
+            shard = intersection(fsdp_slice, split_slice)
+            component_start = 0
+            if shard.start != shard.stop:
+                component_start = shard.start - split_slice.start
+                assert component_start % trailing_numel == 0, (
+                    f"SWiGLU component shard is not aligned with tensor rows: "
+                    f"component_start={component_start}, trailing_numel={trailing_numel}, "
+                    f"meta_shape={meta_shape}, shard={shard}, split_slice={split_slice}"
+                )
+                assert data.numel() % trailing_numel == 0, (
+                    f"SWiGLU component shard size is not aligned with tensor rows: "
+                    f"numel={data.numel()}, trailing_numel={trailing_numel}, "
+                    f"meta_shape={meta_shape}, shard={shard}, split_slice={split_slice}"
+                )
+
+            chunk_offsets = [0] * len(meta_shape)
+            chunk_offsets[swiglu_shard_axis] = component_start // trailing_numel
+            chunk_sizes = list(data.shape)
+            tp_partition_dim = get_mcore_tensor_parallel_partition_dim(meta)
+            if tp_partition_dim is not None:
+                tp_rank = dist.get_rank(tp_mesh.get_group())
+                chunk_offsets[tp_partition_dim] += tp_rank * meta_shape[tp_partition_dim]
+
+            dtensor = make_fsdp_dtensor(
+                data.data,
+                meta,
+                dist_index=megatron_fsdp_dist_index,
+                is_expert_param=is_expert_param,
+                run_check=False,
+                update_uneven_dtensor_chunk_meta=False,
+            )
+            set_explicit_dtensor_chunk_metadata(dtensor, chunk_offsets, chunk_sizes)
+            return dtensor
+
+        weight_w = make_swiglu_split_dtensor(weight_w, w_meta, w_slice)
+        weight_v = make_swiglu_split_dtensor(weight_v, v_meta, v_slice)
         return weight_w, weight_v
 
     model_state_dict = model_state_dict.copy()
@@ -584,14 +609,12 @@ def handle_gdn_in_state_dict(model, model_state_dict, optimizer_state_dict):
             if shard.start != shard.stop:
                 component_start = shard.start - comp_slice.start
                 assert component_start % trailing_numel == 0, (
-                    f"GDN component shard is not aligned with tensor rows: "
-                    f"component_start={component_start}, trailing_numel={trailing_numel}, "
-                    f"meta_shape={meta_shape}, shard={shard}, comp_slice={comp_slice}"
+                    f"Unaligned GDN component shard: component_start={component_start}, "
+                    f"trailing_numel={trailing_numel}"
                 )
                 assert comp_data.numel() % trailing_numel == 0, (
-                    f"GDN component shard size is not aligned with tensor rows: "
-                    f"numel={comp_data.numel()}, trailing_numel={trailing_numel}, "
-                    f"meta_shape={meta_shape}, shard={shard}, comp_slice={comp_slice}"
+                    f"Unaligned GDN component shard size: numel={comp_data.numel()}, "
+                    f"trailing_numel={trailing_numel}"
                 )
 
             chunk_offsets = [0] * len(meta_shape)


### PR DESCRIPTION
## Summary

[#4623](https://github.com/NVIDIA/Megatron-LM/pull/4623) fixes the small/dense Megatron-LM optimizer CPU offload repro from [#4910](https://github.com/NVIDIA/Megatron-LM/issues/4910), but it does not fix the full Qwen3.5-35B-A3B failure reported in the latest #4910 comment.

The remaining failure happens when saving a Megatron-FSDP `fsdp_dtensor` optimizer checkpoint with optimizer CPU
offload enabled. The run reaches checkpoint save, then fails while splitting GDN optimizer state in `handle_gdn_in_state_dict()` because the generated DTensor chunk metadata does not describe the actual FSDP/TP- local shard layout.

This PR adds explicit DCP chunk metadata for those cases instead of letting the generic uneven-DTensor preprocessing recompute it incorrectly.

## Problem

  The full-model repro in #4910 still fails after merging #4623 into latest `dev`:

```text
  AssertionError: [Megatron-FSDP] DTensor chunk metadata boundary check failed.
  Offsets: (0, 0, 0), Sizes: (0, 1, 4),
  Global shape: torch.Size([1024, 1, 4]),
  Local shape: torch.Size([0, 1, 4])
```

  Some ranks also have non-empty local shards but still fail the same boundary check. This indicates that the
  checkpoint metadata does not correctly describe where each GDN component shard belongs in the global tensor.

  The problematic path is specific to FSDP DTensor checkpoint preprocessing for GDN fused parameters and optimizer
  state.

## Changes

  - Add an explicit metadata marker for DTensors whose DCP chunk metadata has already been set by Megatron-FSDP.
  - Skip generic update_uneven_dtensor_chunk_metadata() for tensors marked with explicit metadata.
  - Attach DCP __create_chunk_list__ and __create_write_items__ hooks to both the DTensor and its local tensor.
  - Add TP-aware offsets for flat optimizer-state DTensors:
      - previous offset: fsdp_slice.start
      - new offset: tp_offset + fsdp_slice.start
  - Compute explicit chunk offsets/sizes when splitting GDN fused tensors into logical component tensors.


## Why

  For TP-sharded parameters, fsdp_slice.start alone is not enough to describe the global checkpoint offset. Each TP rank owns a different TP-local portion of the logical global tensor, so DCP metadata needs the TP-rank offset as well.

  For GDN fused parameters, optimizer state is split into logical components such as query/key/value/z/beta/alpha. After this split, rank-local component shards are not always representable by the generic rank-order uneven-DTensor metadata computation. The checkpoint writer needs explicit offsets and sizes for the component shard that this rank actually owns.

## Related Issues / PRs

  - Follow-up to [#4623](https://github.com/NVIDIA/Megatron-LM/pull/4623)
  - Addresses the remaining full-model failure reported in [#4910](https://github.com/NVIDIA/Megatron-LM/issues/4910)

## Summary by Sourcery

Fix FSDP DTensor optimizer and GDN fused-parameter checkpointing metadata, improve MoE HybridEP compatibility with sequence packing and transport backends, and add end-to-end MoE recipes for DeepSeek-V3 and Qwen3-235B across multiple GPU platforms.

Bug Fixes:
- Correct DTensor chunk metadata generation for FSDP-sharded optimizer state, including TP-aware offsets for flat tensors.
- Provide explicit and validated chunk metadata when splitting GDN fused tensors into logical components to avoid incorrect uneven-DTensor preprocessing.
- Skip uneven-DTensor metadata recomputation for DTensors with explicit Megatron-FSDP chunk metadata to prevent boundary assertion failures.
- Ensure HybridEP MoE token dispatcher handles THD sequence packing by padding metadata and hidden states to a common token count and trimming after combine.
- Avoid allocating RDMA buffers for local-only expert-parallel groups when DeepEP may not expose RDMA hints.
- Reset HybridEP buffers between tests to avoid cross-test contamination.

Enhancements:
- Treat LinearCrossEntropyModule as column-parallel for the Megatron FSDP adapter to integrate with TP sharding.
- Extend sequence packing support to flex MoE token dispatcher types in transformer configuration.
- Add THD sequence-packing helpers and an end-to-end multi-parallelism MoE test covering HybridEP and DeepEP dispatchers.
- Refine GDN fused-parameter handling to infer TP sharding from metadata and mark TP-local tensors appropriately for DCP planning.

Build:
- Add YAML-based MoE training recipes for DeepSeek-V3 and Qwen3-235B across GB200/GB300/B200/H100 GPU configurations with MXFP8 and BF16 variants, including CUDA graph, paged stash, and HybridEP/DeepEP options.

Deployment:
- Add Dockerfile-embedded dependencies and environment configuration to support DeepEP/HybridEP, FA/FA4, TransformerEngine, FlashMLA, and related libraries in new large-scale MoE recipes.

Documentation:
- Introduce a MoE recipes README indexing new DeepSeek-V3 and Qwen3-235B training recipes and their parallelism/topology characteristics.

Tests:
- Add an end-to-end packed THD attention + MoE forward/backward test exercising alltoall, DeepEP, and HybridEP token dispatchers under multi-parallelism.