### PR TITLE
examples/multimodal_dev: docs + Victarry review fixes + vision patch merger parity test

### DIFF
--- a/examples/multimodal_dev/README.md
+++ b/examples/multimodal_dev/README.md
@@ -34,6 +34,66 @@ torchrun --nproc_per_node=8 multimodal_dev/pretrain_multimodal.py \
     ... # other Megatron args (--num-layers, --hidden-size, etc.)
 ```
 
+## Checkpoint Conversion (HF → Megatron-FSDP DTensor)
+
+Convert a HuggingFace release to a Megatron-FSDP DTensor checkpoint via
+[Megatron-Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) before
+pretraining from pretrained weights.
+
+### Setup
+
+Clone Bridge and pin its `3rdparty/Megatron-LM` submodule to this branch:
+
+```bash
+git clone --recurse-submodules https://github.com/NVIDIA-NeMo/Megatron-Bridge.git
+cd Megatron-Bridge/3rdparty/Megatron-LM
+git remote add wplf https://github.com/wplf/Megatron-LM.git
+git fetch wplf feat/qwen35-vl-example
+git checkout feat/qwen35-vl-example
+cd ../..
+```
+
+### Convert
+
+Single 8×GPU node, EP=8 / TP=CP=1; substitute any Qwen3.5 variant for
+`--hf-model`:
+
+```bash
+PYTHONPATH=./src:./3rdparty/Megatron-LM/ \
+  torchrun --nproc_per_node=8 \
+  examples/conversion/mfsdp/convert_checkpoints_fsdp.py import \
+  --hf-model Qwen/Qwen3.5-35B-A3B \
+  --megatron-path ${WORKSPACE}/models/Qwen/Qwen3.5-35B-A3B-fsdp \
+  --ckpt-format fsdp_dtensor \
+  --ep 8
+```
+
+HF weights are auto-fetched on first run via `huggingface_hub`. Adjust
+`--tp` / `--cp` / `--ep` to match the training topology (must satisfy
+`WORLD_SIZE % (TP*CP*EP) == 0`).
+
+### Output
+
+```
+${WORKSPACE}/models/Qwen/Qwen3.5-35B-A3B-fsdp/
+├── iter_0000000/
+│   ├── __0_0.distcp .. __7_0.distcp   # FSDP DTensor shards, one per rank (~18 GB each for 35B-A3B)
+│   ├── .metadata
+│   ├── run_config.yaml
+│   └── train_state.pt
+├── latest_checkpointed_iteration.txt
+└── latest_train_state.pt
+```
+
+### Bridge dependency
+
+Requires
+[NVIDIA-NeMo/Megatron-Bridge#3987](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3987)
+(skip tokenizer save). Without that fix the checkpoint is still written
+correctly but the script exits non-zero after save with
+`AttributeError: 'TokenizerConfig' object has no attribute 'make_vocab_size_divisible_by'`
+against this branch's `megatron.core.tokenizers.utils.build_tokenizer`.
+
 ## Architecture
 
 `pretrain_multimodal.py` is **model-agnostic**. All model-specific logic

--- a/examples/multimodal_dev/data/cord_v2.py
+++ b/examples/multimodal_dev/data/cord_v2.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Simple VLM dataset for multimodal_dev training.
+"""CORD-V2 VLM dataset for multimodal_dev training.
 
 Single-turn image-text dataset using a HuggingFace ``AutoProcessor`` for
-tokenization and image preprocessing.  Currently supports CORD-V2 (receipt
-OCR).  No multi-turn support — each sample is one image + question →
-answer pair.
+tokenization and image preprocessing.  This module is the reference
+implementation for the CORD-V2 receipt-OCR dataset.  No multi-turn support —
+each sample is one image + question → answer pair.
 
 Each image is preprocessed via ``qwen_vl_utils.process_vision_info`` and
 fed to the processor with Qwen-VL's recommended ``min_pixels`` /
@@ -20,6 +20,32 @@ Usage::
         --model-arch qwen35_vl --dataset-provider cord_v2 \\
         --hf-processor-path Qwen/Qwen3.5-397B-A17B \\
         --total-seq-length 4096 --use-vanilla-collate-fn
+
+Adding another VLM dataset
+--------------------------
+
+The dataset layer mirrors the model layer's registry pattern: each dataset
+ships its own module and a ``train_valid_test_datasets_provider`` factory,
+and the model's registry entry maps a ``--dataset-provider`` name to that
+factory's dotted path.  To add a new dataset (e.g. NLVR2):
+
+1. Create ``examples/multimodal_dev/data/<name>.py`` with::
+
+       def train_valid_test_datasets_provider(train_val_test_num_samples):
+           ...  # build datasets using args from get_args()
+           return train_ds, val_ds, test_ds
+
+2. Register it under the relevant model in
+   ``examples/multimodal_dev/models/__init__.py``::
+
+       MODEL_REGISTRY["qwen35_vl"]["dataset_providers"]["<name>"] = (
+           "examples.multimodal_dev.data.<name>"
+           ".train_valid_test_datasets_provider"
+       )
+
+3. Launch with ``--dataset-provider <name>``.
+
+No edits to ``pretrain_multimodal.py`` or ``forward_step.py`` are required.
 """
 
 import json

--- a/examples/multimodal_dev/models/__init__.py
+++ b/examples/multimodal_dev/models/__init__.py
@@ -54,7 +54,7 @@ MODEL_REGISTRY = {
                 ".train_valid_test_datasets_provider"
             ),
             "cord_v2": (
-                "examples.multimodal_dev.data.vlm_dataset"
+                "examples.multimodal_dev.data.cord_v2"
                 ".train_valid_test_datasets_provider"
             ),
         },

--- a/examples/multimodal_dev/models/qwen35_vl/mrope.py
+++ b/examples/multimodal_dev/models/qwen35_vl/mrope.py
@@ -55,6 +55,7 @@ def _build_sample_mrope_positions(
     vision_tokens = sample_input_ids[vision_start_indices + 1]
     image_nums = int((vision_tokens == image_token_id).sum())
     video_nums = int((vision_tokens == video_token_id).sum())
+    # TODO: fuse into a kernel to drop the per-iter GPU<->CPU sync.
     input_tokens = sample_input_ids.tolist()
     llm_pos_ids_list: list = []
     st = 0

--- a/examples/multimodal_dev/models/qwen35_vl/vision_encoder.py
+++ b/examples/multimodal_dev/models/qwen35_vl/vision_encoder.py
@@ -249,8 +249,8 @@ class Qwen35VLPatchMerger(MegatronModule):
         hidden_states = self.patch_norm(hidden_states)
         merged = hidden_states.view(-1, self.merge_dim)
         merged, _ = self.linear_fc1(merged)
-        # NOTE: Official HuggingFace uses default approximate='none' in Qwen3VLVisionPatchMerger.
-        merged = torch.nn.functional.gelu(merged, approximate="tanh")
+        # Match official HuggingFace Qwen3VLVisionPatchMerger (default approximate='none').
+        merged = torch.nn.functional.gelu(merged, approximate="none")
         merged, _ = self.linear_fc2(merged)
         return merged
 

--- a/examples/multimodal_dev/pretrain_multimodal.py
+++ b/examples/multimodal_dev/pretrain_multimodal.py
@@ -148,6 +148,16 @@ if __name__ == "__main__":
         extra_args_provider=add_multimodal_args,
         args_defaults={},
     )
+    # multimodal_dev's model_provider builds the full model on every rank and
+    # does not honor pre_process / post_process pipeline-stage flags. PP>1
+    # would silently violate Megatron's pipeline-parallel contract.
+    if args.pipeline_model_parallel_size > 1:
+        raise ValueError(
+            "multimodal_dev does not support pipeline_model_parallel_size > 1 "
+            f"(got {args.pipeline_model_parallel_size}). The model provider "
+            "builds the full model on every rank; pipeline-stage splitting is "
+            "not wired through. Run with --pipeline-model-parallel-size 1."
+        )
     full_config = pretrain_cfg_container_from_args(args)
     pretrain(
         full_config,

--- a/examples/multimodal_dev/scripts/run_qwen35_vl.sh
+++ b/examples/multimodal_dev/scripts/run_qwen35_vl.sh
@@ -9,9 +9,12 @@
 #   MODEL_VARIANT: proxy (default), 0.8b, 2b, 4b, 9b, 27b, 35b_a3b, 122b_a10b, 397b_a17b, 35b_a3b_light
 #   CKPT_LOAD: path to a pre-converted checkpoint to load (enables --load + --finetune)
 #   CKPT_FORMAT: checkpoint format override (e.g. torch_dist); auto-detected when empty
-#   TP, EP, PP: parallelism sizes
+#   TP, EP, PP: parallelism sizes (PP must stay 1; multimodal_dev does not
+#               support pipeline parallelism)
 #   MBS, GBS: micro/global batch sizes
 #   NUM_LAYERS, NUM_EXPERTS: override for proxy testing
+#   FORCE_LOAD_BALANCING: set to 1 to enable --moe-router-force-load-balancing
+#                         (perf / mock-data only; OFF for real finetuning)
 #   LAUNCHER: torchrun (default) or python
 #   PROFILE: set to 1 to enable Nsight Systems profiling (default: 0)
 #   PROFILE_STEP_START/PROFILE_STEP_END: profiled iteration window (default: 4-5)
@@ -48,9 +51,15 @@ GBS=${GBS:-16}
 
 # Parallelism
 TP=${TP:-1}
-EP=${EP:-2}
+# EP defaults to 1; MoE variants override via the variant case block below.
+EP=${EP:-1}
 PP=${PP:-1}
 CP=${CP:-1}
+# Gate --moe-router-force-load-balancing behind an explicit opt-in. Useful for
+# perf / mock-data benchmarking (it disables the auxiliary load-balancing loss
+# coupling so router routes are perfectly uniform), but it must be off for any
+# real fine-tuning / convergence run because it freezes data-dependent routing.
+FORCE_LOAD_BALANCING=${FORCE_LOAD_BALANCING:-0}
 
 # Variant-aware architecture defaults.
 # The model provider builds configs from the variant dict in
@@ -168,6 +177,16 @@ case "$MODEL_VARIANT" in
         VISION_NUM_LAYERS=${VISION_NUM_LAYERS:-27}
         ;;
 esac
+
+# Fail fast on inconsistent expert-parallelism configuration. Dense variants
+# (NUM_EXPERTS=0) do not emit any --num-experts / MoE args, so forwarding
+# --expert-model-parallel-size > 1 would trip Megatron's arg validation.
+if [ "${NUM_EXPERTS:-0}" -eq 0 ] && [ "$EP" -gt 1 ]; then
+    echo "ERROR: MODEL_VARIANT=$MODEL_VARIANT has NUM_EXPERTS=0 (dense) but EP=$EP." >&2
+    echo "       Set EP=1 for dense variants, or pick a MoE variant." >&2
+    exit 1
+fi
+
 SEQ_LEN=${SEQ_LEN:-4096}
 
 WANDB_PROJECT=${WANDB_PROJECT:-'qwen35-vl-0524'}
@@ -348,7 +367,6 @@ GPT_MODEL_ARGS=(
     --linear-num-key-heads 16
     --linear-num-value-heads "$LINEAR_NUM_VALUE_HEADS"
     --make-vocab-size-divisible-by 485
-    --moe-router-force-load-balancing
 )
 
 # --- Tied / untied embeddings ---
@@ -391,6 +409,11 @@ if [ "${NUM_EXPERTS:-0}" -gt 0 ]; then
         --moe-permute-fusion
         --moe-router-fusion
     )
+    # Perf / mock-data only: forces uniform router decisions; do NOT enable for
+    # real finetuning (it freezes data-dependent routing).
+    if [ "$FORCE_LOAD_BALANCING" -eq 1 ]; then
+        MOE_ARGS+=( --moe-router-force-load-balancing )
+    fi
 fi
 
 # --- Recompute ---

--- a/examples/multimodal_dev/tests/test_vision_patch_merger_parity.py
+++ b/examples/multimodal_dev/tests/test_vision_patch_merger_parity.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Numerical parity for ``Qwen35VLPatchMerger`` vs HuggingFace reference.
+
+The HuggingFace reference (``Qwen3VLVisionPatchMerger`` in
+``transformers/models/qwen3_vl/modeling_qwen3_vl.py``, branch
+``use_postshuffle_norm=False``) is reproduced inline so this test does not
+require ``transformers`` to be installed.  The HF module is verbatim::
+
+    self.norm       = nn.LayerNorm(hidden_size, eps=1e-6)
+    self.linear_fc1 = nn.Linear(merge_dim, merge_dim)
+    self.act_fn     = nn.GELU()             # default approximate='none'
+    self.linear_fc2 = nn.Linear(merge_dim, out_hidden_size)
+
+    x = self.norm(x)
+    x = x.view(-1, merge_dim)
+    x = self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+
+With matching dims and weights copied across, the Megatron
+implementation must agree:
+
+  * fp32 forward:  max-abs diff <= 1e-4  (TE LayerNorm vs nn.LayerNorm
+    have different fused reduction order; ~1e-5 absolute residual is
+    structural and not a real divergence)
+  * bf16 forward:  max-abs diff <= 5e-2  (bf16 ceiling for two-layer MLP)
+
+Run with::
+
+    torchrun --nproc_per_node=1 \\
+        examples/multimodal_dev/tests/test_vision_patch_merger_parity.py
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../.."),
+)
+if _REPO_ROOT in sys.path:
+    sys.path.remove(_REPO_ROOT)
+sys.path.insert(0, _REPO_ROOT)
+
+from megatron.core import parallel_state as ps
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+from examples.multimodal_dev.models.qwen35_vl.vision_encoder import Qwen35VLPatchMerger
+
+
+# Match Qwen3.5-VL 9B / 397B-A17B vision tower dims.
+HIDDEN_SIZE = 1152
+OUT_HIDDEN_SIZE = 3584
+SPATIAL_MERGE_SIZE = 2
+NUM_PATCHES = 64  # must be divisible by spatial_merge_size ** 2
+
+ATOL_FP32 = 1e-4
+RTOL_FP32 = 1e-3
+ATOL_BF16 = 5e-2
+RTOL_BF16 = 5e-2
+
+
+class HFPatchMergerReference(nn.Module):
+    """Inline HF ``Qwen3VLVisionPatchMerger`` (use_postshuffle_norm=False)."""
+
+    def __init__(self, hidden_size: int, out_hidden_size: int, spatial_merge_size: int):
+        super().__init__()
+        self.merge_dim = hidden_size * (spatial_merge_size ** 2)
+        self.norm = nn.LayerNorm(hidden_size, eps=1e-6)
+        self.linear_fc1 = nn.Linear(self.merge_dim, self.merge_dim)
+        self.act_fn = nn.GELU()  # approximate='none' by default
+        self.linear_fc2 = nn.Linear(self.merge_dim, out_hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        x = self.norm(hidden_states)
+        x = x.view(-1, self.merge_dim)
+        x = self.linear_fc1(x)
+        x = self.act_fn(x)
+        x = self.linear_fc2(x)
+        return x
+
+
+def _init_distributed() -> int:
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    return local_rank
+
+
+def _init_megatron_parallel() -> None:
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(tensor_model_parallel_size=1)
+    model_parallel_cuda_manual_seed(42)
+
+
+def _build_config(dtype: torch.dtype) -> TransformerConfig:
+    is_bf16 = dtype is torch.bfloat16
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=HIDDEN_SIZE,
+        ffn_hidden_size=HIDDEN_SIZE,
+        num_attention_heads=8,
+        kv_channels=HIDDEN_SIZE // 8,
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        sequence_parallel=False,
+        bf16=is_bf16,
+        params_dtype=dtype,
+        pipeline_dtype=dtype,
+        add_bias_linear=True,
+        gated_linear_unit=False,
+        normalization="LayerNorm",
+        layernorm_epsilon=1e-6,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+    )
+
+
+def _copy_hf_to_megatron(hf: HFPatchMergerReference, mcore: Qwen35VLPatchMerger) -> None:
+    """TP=1: 1:1 parameter copy between HF nn.Module and the MCore module."""
+    with torch.no_grad():
+        mcore.patch_norm.weight.copy_(hf.norm.weight.to(mcore.patch_norm.weight.dtype))
+        mcore.patch_norm.bias.copy_(hf.norm.bias.to(mcore.patch_norm.bias.dtype))
+        mcore.linear_fc1.weight.copy_(hf.linear_fc1.weight.to(mcore.linear_fc1.weight.dtype))
+        mcore.linear_fc1.bias.copy_(hf.linear_fc1.bias.to(mcore.linear_fc1.bias.dtype))
+        mcore.linear_fc2.weight.copy_(hf.linear_fc2.weight.to(mcore.linear_fc2.weight.dtype))
+        mcore.linear_fc2.bias.copy_(hf.linear_fc2.bias.to(mcore.linear_fc2.bias.dtype))
+
+
+def _run_one(dtype: torch.dtype, atol: float, rtol: float, device: torch.device, seed: int = 42) -> None:
+    torch.manual_seed(seed)
+
+    hf_ref = HFPatchMergerReference(
+        hidden_size=HIDDEN_SIZE,
+        out_hidden_size=OUT_HIDDEN_SIZE,
+        spatial_merge_size=SPATIAL_MERGE_SIZE,
+    ).to(device=device, dtype=dtype).eval()
+
+    config = _build_config(dtype)
+    mcore = Qwen35VLPatchMerger(
+        config=config,
+        hidden_size=HIDDEN_SIZE,
+        out_hidden_size=OUT_HIDDEN_SIZE,
+        spatial_merge_size=SPATIAL_MERGE_SIZE,
+    ).to(device=device, dtype=dtype).eval()
+
+    _copy_hf_to_megatron(hf_ref, mcore)
+
+    x = torch.randn(NUM_PATCHES, HIDDEN_SIZE, device=device, dtype=dtype)
+
+    with torch.no_grad():
+        y_hf = hf_ref(x)
+        y_mcore = mcore(x)
+
+    assert y_hf.shape == y_mcore.shape, (y_hf.shape, y_mcore.shape)
+    diff = (y_hf - y_mcore).abs()
+    print(
+        f"[{dtype}] shape={tuple(y_hf.shape)} "
+        f"max_abs_diff={diff.max().item():.3e} "
+        f"mean_abs_diff={diff.mean().item():.3e} "
+        f"hf_norm={y_hf.float().norm().item():.4f} "
+        f"mcore_norm={y_mcore.float().norm().item():.4f}"
+    )
+    torch.testing.assert_close(y_mcore, y_hf, atol=atol, rtol=rtol)
+
+
+def main() -> None:
+    local_rank = _init_distributed()
+    _init_megatron_parallel()
+    device = torch.device(f"cuda:{local_rank}")
+
+    _run_one(torch.float32, ATOL_FP32, RTOL_FP32, device)
+    _run_one(torch.bfloat16, ATOL_BF16, RTOL_BF16, device)
+
+    if int(os.environ.get("RANK", 0)) == 0:
+        print(
+            "\nPASS: Qwen35VLPatchMerger logits match HF Qwen3VLVisionPatchMerger "
+            "in both fp32 and bf16."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Cherry-picked from `feat/qwen35-vl-example` onto
`jinliangl/qwen35-vl-hybridep-deploy-pr4715` so the review diff is scoped
to just three commits of `examples/multimodal_dev/` work:

| Commit | Summary |
|---|---|
| `075fe8935` | `docs(examples/multimodal_dev): add checkpoint conversion guide to README` — new `## Checkpoint Conversion (HF → Megatron-FSDP DTensor)` section (Setup / Convert / Output / Bridge dependency) |
| `4e853ea47` | `fix(examples/multimodal_dev): address Victarry review feedback` — resolves the 6 inline review comments on upstream PR #4751: PatchMerger GELU `tanh` → `none` (HF parity), PP>1 fail-fast in `pretrain_multimodal.py`, EP default `2 → 1` + `NUM_EXPERTS=0 && EP>1` fail-fast in `run_qwen35_vl.sh`, `--moe-router-force-load-balancing` gated behind `FORCE_LOAD_BALANCING=1`, `vlm_dataset.py → cord_v2.py` rename + registry path update + extensibility docstring, MRoPE precompute TODO note |
| `2130f4210` | `test(examples/multimodal_dev): add Qwen35VLPatchMerger HF parity test` — new `tests/test_vision_patch_merger_parity.py`. Inlines HF `Qwen3VLVisionPatchMerger`, copies state-dict 1:1 (TP=1), asserts logits parity. Runs on H100: fp32 max-abs `2.55e-5` (atol=1e-4), bf16 max-abs `3.91e-3` (atol=5e-2); test passes |

Total: 9 files / +325 -10 (incl. 1 rename).

Verified on cw: parity test job 12224061 COMPLETED 0:0 in 43s.

## Summary by Sourcery

Document checkpoint conversion from HuggingFace to Megatron-FSDP DTensor, tighten multimodal training/launch configuration safety, and add a numerical parity test for the Qwen35VLPatchMerger vision module against the HuggingFace reference.

Enhancements:
- Disallow pipeline parallelism in multimodal_dev by failing fast when pipeline_model_parallel_size > 1 to prevent unsupported configurations.
- Clarify the CORD-V2 dataset module naming and description to better reflect its role as the reference CORD-V2 VLM dataset.
- Align the Qwen35VLPatchMerger GELU activation with the HuggingFace Qwen3VLVisionPatchMerger behavior for numerical consistency.
- Document a performance note on MRoPE position metadata computation to guide future optimization of CUDA graph compatibility.

Documentation:
- Add a checkpoint conversion guide for importing HuggingFace Qwen3.5 models into Megatron-FSDP DTensor via Megatron-Bridge, including setup, invocation, and dependency notes.

Tests:
- Introduce a distributed parity test that compares Qwen35VLPatchMerger outputs to an inlined HuggingFace reference implementation in fp32 and bf16 with strict numerical tolerances.

Chores:
- Update the Qwen35-VL example launch script to default expert parallelism to 1, gate forced MoE router load-balancing behind an explicit opt-in flag, and fail fast on invalid dense-model expert-parallel configurations.
- Switch the dataset registry entry from the generic VLM dataset module to the renamed CORD-V2-specific implementation.