### PR TITLE
Add optional mcore GDN optimized wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-__pycache__
+__pycache__/
+*.pyc
 *.so
 build
 .coverage_*
@@ -16,6 +17,7 @@ onelogger.err
 runs/
 /test_cases/
 **/dist/
+AGENTS.md
 
 # Sphinx documentation
 docs/_build

--- a/docs/gdn_cuda_optimization_reproduction.md
+++ b/docs/gdn_cuda_optimization_reproduction.md
@@ -8,26 +8,94 @@ gated-delta-rule calls through that package without modifying FLA source.
 ## Install
 
 Use a GPU container that already has `mcore_gdn_opt` and its CUDA extensions
-installed, or install the package from the internal repository before running
-Megatron-LM:
+installed, or build + install the package from the internal repository before
+running Megatron-LM.
+
+> **Use commit `12605c5` or later.** Earlier kernel commits produce wrong or
+> NaN gradients — see [Kernel version history](#kernel-version-history-dhu-backward)
+> below. `12605c5` is the first commit that is both numerically correct and
+> NaN-free at training scale.
 
 ```bash
-pip install -e . --user --no-build-isolation
-
 git clone https://gitlab-master.nvidia.com/bhsueh/mcore_gdn_opt.git
 cd mcore_gdn_opt
-git checkout 3a371f53eeec24cc1d9da4a01584f3ec9f8f44e5
+git checkout 12605c515bdbc1f239df991a9cea570f7e79d234
+
+# IMPORTANT: use the PINNED submodule commits. Do NOT use
+# `git submodule update --remote` — it tracks the branch tip of
+# `gated_delta_rule_bwd` and pulls an OLDER, buggy DHU kernel.
 git submodule update --init --recursive
+
+# The nested `gated_delta_rule_bwd/third_party/cutlass` submodule is sometimes
+# left unpopulated; point it at the top-level cutlass so the SM100 DHU kernel
+# can build.
+if [ ! -e third_party/gated_delta_rule_bwd/third_party/cutlass/include ]; then
+  rm -rf third_party/gated_delta_rule_bwd/third_party/cutlass
+  ln -s "$PWD/third_party/cutlass" third_party/gated_delta_rule_bwd/third_party/cutlass
+fi
 export CUTLASS_PATH="${PWD}/third_party/cutlass"
 
-python -m pip install -e third_party/gated_delta_rule_bwd --no-build-isolation
-python -m pip install -e chunk_bwd_kernel_dqkwg --no-build-isolation
-python -m pip install -e chunk_gated_delta_rule_fwd --no-build-isolation
-python -m pip install -e . --no-build-isolation
+# FLA must come from the pinned submodule (the wrapper imports
+# `fla.ops.gated_delta_rule.chunk_fwd`, present only in that FLA commit).
+python -m pip install --no-build-isolation --no-deps \
+  third_party/gated_delta_rule_bwd/third_party/fla
+
+# Build + install the CUDA extensions (editable) and the package.
+python -m pip install -e third_party/gated_delta_rule_bwd --no-build-isolation   # chunk_delta_h_bwd_sm100 (fwd_h / wy_bwd / dhu)
+python -m pip install -e chunk_bwd_kernel_dqkwg       --no-build-isolation        # dqkwg
+python -m pip install -e chunk_gated_delta_rule_fwd   --no-build-isolation        # fwd_h (forward state recompute)
+python -m pip install -e chunk_delta_fused_fwd_bwd    --no-build-isolation        # fused dv_dhu (bundled since 5661cfa)
+python -m pip install -e .                            --no-build-isolation
 ```
 
 Do not use `PYTHONPATH` or ad-hoc `sys.modules` injection for these tests. The
 package and CUDA extensions should be installed in editable mode.
+
+### Building portable wheels (install into a fixed container without rebuilding)
+
+The CUDA compile is slow (~30–40 min). Build wheels once, then force-reinstall
+them into a running container (the wheels are pinned to e.g. py3.12 / torch2.12 /
+SM100a aarch64):
+
+```bash
+for d in third_party/gated_delta_rule_bwd chunk_bwd_kernel_dqkwg \
+         chunk_gated_delta_rule_fwd chunk_delta_fused_fwd_bwd .; do
+  python -m pip wheel --no-build-isolation --no-deps -w ./wheels "./$d"
+done
+pip install --no-deps --force-reinstall ./wheels/*.whl
+```
+
+`--force-reinstall` cleanly replaces the image's editable installs with the wheel
+`.so` (verified: the imported `.so` becomes byte-identical to the wheel's).
+
+> **Fused `dv_dhu` (DV_DHU=1) install caveat.** The compiled
+> `chunk_delta_fused_fwd_bwd_cuda` extension installs as a *top-level* module, but
+> its wrapper `chunk_delta_fused_fwd_bwd/__init__.py` imports it as a *submodule*
+> (`from . import chunk_delta_fused_fwd_bwd_cuda`), so a plain wheel install fails
+> with `ImportError: chunk_delta_fused_fwd_bwd_cuda extension not found`. Until the
+> packaging is fixed, copy the `.so` into the package dir after installing:
+> ```bash
+> SO=$(python -c "import chunk_delta_fused_fwd_bwd_cuda as m; print(m.__file__)")
+> PKG=$(python -c "import chunk_delta_fused_fwd_bwd, os; print(os.path.dirname(chunk_delta_fused_fwd_bwd.__file__))")
+> cp "$SO" "$PKG/"
+> ```
+> The standalone `dhu` path (`DV_DHU=0, ENABLE_DHU=1`) and the editable `-e` install
+> do not need this.
+
+### Kernel version history (DHU backward)
+
+| `mcore_gdn_opt` | submodule `gated_delta_rule_bwd` | status |
+|---|---|---|
+| `3a371f5` | `949c959` | backward grads wrong (DHU dk/dv ~1.4×, WY dβ ~4.6×) |
+| `297386a` | `f2351d3` | accuracy fixed, but DHU decay-reciprocal **underflow → NaN** on real inputs |
+| `5661cfa` | `2e6d892` | still NaN: the standalone cute DHU kernel emits NaN under very-negative `g` |
+| **`12605c5`** | — | **FIXED** — finite and numerically matches FLA; training-safe |
+
+Validation of `12605c5`: Qwen3.5-VL 397B proxy, 8×GB200, 20 steps, `DV_DHU=0`
+(so the standalone cute `chunk_gated_delta_rule_bwd_dhu_cute` kernel is the one
+running). grad norm finite for all steps (0 NaN iterations); loss / grad-norm
+track the Triton(FLA) baseline to ~4 decimals (iter1 `13.24028` / `15.12`,
+iter20 `0.073` / `0.506`).
 
 ## Runtime Flags
 

--- a/docs/gdn_cuda_optimization_reproduction.md
+++ b/docs/gdn_cuda_optimization_reproduction.md
@@ -1,0 +1,136 @@
+# GDN CUDA Optimization Reproduction
+
+This note covers the current GatedDeltaNet CUDA optimization test flow for
+Megatron-LM on B200/H100. The optimized kernels are provided by
+the `mcore_gdn_opt` Python package; Megatron can optionally route its
+gated-delta-rule calls through that package without modifying FLA source.
+
+## Install
+
+Use a GPU container that already has `mcore_gdn_opt` and its CUDA extensions
+installed, or install the package from the internal repository before running
+Megatron-LM:
+
+```bash
+pip install -e . --user --no-build-isolation
+
+git clone https://gitlab-master.nvidia.com/bhsueh/mcore_gdn_opt.git
+cd mcore_gdn_opt
+git checkout 3a371f53eeec24cc1d9da4a01584f3ec9f8f44e5
+git submodule update --init --recursive
+export CUTLASS_PATH="${PWD}/third_party/cutlass"
+
+python -m pip install -e third_party/gated_delta_rule_bwd --no-build-isolation
+python -m pip install -e chunk_bwd_kernel_dqkwg --no-build-isolation
+python -m pip install -e chunk_gated_delta_rule_fwd --no-build-isolation
+python -m pip install -e . --no-build-isolation
+```
+
+Do not use `PYTHONPATH` or ad-hoc `sys.modules` injection for these tests. The
+package and CUDA extensions should be installed in editable mode.
+
+## Runtime Flags
+
+| Case | Flags |
+|---|---|
+| Triton baseline | `MCORE_GDN_USE_OPT_WRAPPER=0` |
+| wrapper auto | `MCORE_GDN_USE_OPT_WRAPPER=1 MCORE_GDN_OPT_BACKEND=auto` |
+| `wy_bwd` only | `MCORE_GDN_USE_OPT_WRAPPER=1 MCORE_GDN_OPT_BACKEND=cuda` with other optimized stages disabled |
+| `dhu` only | `MCORE_GDN_USE_OPT_WRAPPER=1 MCORE_GDN_OPT_BACKEND=cuda` with other optimized stages disabled |
+| `dqkwg` only | `MCORE_GDN_USE_OPT_WRAPPER=1 MCORE_GDN_OPT_BACKEND=cuda` with other optimized stages disabled |
+| all three separate | `wy_bwd+dhu+dqkwg` enabled, `fwd_h` and `dv_dhu` disabled |
+| all four | `fwd_h+wy_bwd+dhu+dqkwg` enabled, `dv_dhu` disabled |
+| `fwd_h+wy_bwd+fused_dv_dhu+dqkwg` | `fwd_h+wy_bwd+dv_dhu+dqkwg` enabled, standalone `dhu` disabled |
+
+The `dhu_dqkwg` wrapper is intentionally not exposed as a benchmark scenario
+because the single-kernel DHU+DQKWG path is not implemented. The remaining
+optimized scenarios use standalone `dhu`/`dqkwg` or the real fused `dv_dhu`
+kernel.
+
+## GDN-Only Direct Test
+
+This bypasses the full GPT layer and measures a direct `GatedDeltaNet`
+forward/backward. It checks output, input grad, and parameter grads against the
+Triton baseline.
+
+```bash
+python -m tests.unit_tests.ssm.bench_gdn_cuda_opt \
+  --dtype bf16 \
+  --loss sum \
+  --scenarios baseline,separate,all_four,fwd_h_wy_dv_dhu_dqkwg \
+  --warmup 5 --repeats 20 --rounds 3
+```
+
+Use `--loss square_mean` to reproduce the earlier loss used during debugging,
+and add `--fail-on-accuracy` when the command should return non-zero on any
+accuracy mismatch.
+
+Latest B200 spot check for
+`B=2,T=8192,H=64,D=128,bf16,loss=sum,warmup=3,repeats=10,rounds=3`
+on Megatron-LM `c42dc298a`, `mcore_gdn_opt@9121702`, and
+`gated_delta_rule_bwd@949c959`:
+
+| Scenario | Accuracy vs Triton | Mean us | Speedup |
+|---|---:|---:|---:|
+| Triton baseline | PASS | 15220.135 | 1.000x |
+| CUDA all three separate | FAIL | 13420.346 | 1.134x |
+| CUDA all four | FAIL | 12875.528 | 1.182x |
+
+For this direct `loss=sum` GDN-only check, the optimized scenarios still fail
+the strict gradient comparison against the Triton baseline. The current
+production workflow is validated with `loss=square_mean`; the latest B200 full
+workflow validation passed all requested scenarios and measured `CUDA all four`
+at `12895.830 us` (`1.182x`) and `CUDA fwd_h+wy_bwd+fused_dv_dhu+dqkwg` at
+`12732.651 us` (`1.197x`). Fresh logs:
+`third_party/gdn_doc_loss_sum_20260528_205336.log` and
+`third_party/gdn_full_validation_cb51345_20260528_204219.log`.
+
+## E2E Pytest
+
+This runs the focused GDN CUDA optimization pytest path. It checks correctness
+by default and can print the benchmark table when `MCORE_GDN_UNIT_TEST_PERF=1`.
+
+```bash
+MCORE_GDN_UNIT_TEST_SCENARIOS=baseline,fwd_h_wy_dv_dhu_dqkwg \
+pytest -s tests/unit_tests/ssm/test_gated_delta_net_cuda_opt.py::test_gated_delta_net_cuda_opt_correctness_and_optional_perf -k bf16
+```
+
+To generate the E2E benchmark table with NVTX labels:
+
+```bash
+MCORE_GDN_UNIT_TEST_SCENARIOS=baseline,wy,dhu,dqkwg,separate,all_four,fwd_h_wy_dv_dhu_dqkwg \
+MCORE_GDN_UNIT_TEST_PERF=1 \
+MCORE_GDN_UNIT_TEST_WARMUP=5 \
+MCORE_GDN_UNIT_TEST_REPEATS=20 \
+MCORE_GDN_UNIT_TEST_ROUNDS=3 \
+pytest -s tests/unit_tests/ssm/test_gated_delta_net_cuda_opt.py::test_gated_delta_net_cuda_opt_correctness_and_optional_perf -k bf16
+```
+
+Latest B200 full workflow validation for `loss=square_mean` passed correctness
+for wrapper forced FLA, wrapper auto, wrapper forced CUDA, `CUDA all four`, and
+`CUDA fwd_h+wy_bwd+fused_dv_dhu+dqkwg`. Observed speedups were `1.198x` for
+wrapper auto, `1.182x` for `CUDA all four`, and `1.197x` for
+`CUDA fwd_h+wy_bwd+fused_dv_dhu+dqkwg` versus the Triton baseline.
+
+## Nsight Systems
+
+Use the E2E pytest command above under `nsys profile`. The benchmark emits NVTX
+labels in this format:
+
+```text
+gdn_only/<index>_<scenario_name>/round_<round>/iter_<iter>
+```
+
+Example:
+
+```bash
+MCORE_GDN_UNIT_TEST_SCENARIOS=baseline,fwd_h_wy_dv_dhu_dqkwg \
+MCORE_GDN_UNIT_TEST_PERF=1 \
+MCORE_GDN_UNIT_TEST_WARMUP=5 \
+MCORE_GDN_UNIT_TEST_REPEATS=20 \
+MCORE_GDN_UNIT_TEST_ROUNDS=3 \
+nsys profile -f true -o gdn_e2e_b200 \
+  pytest -s tests/unit_tests/ssm/test_gated_delta_net_cuda_opt.py::test_gated_delta_net_cuda_opt_correctness_and_optional_perf -k bf16
+```
+
+Keep profiler outputs (`*.nsys-rep`, `*.sqlite`, `*.qdrep`) out of commits.

--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 from dataclasses import dataclass, replace
 from typing import List, Optional, Tuple, Union
 
@@ -44,7 +45,14 @@ from megatron.core.utils import deprecate_inference_params, nvtx_range_pop, nvtx
 try:
     from fla.modules.convolution import causal_conv1d
     from fla.modules.l2norm import l2norm
-    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+
+    if os.environ.get("MCORE_GDN_USE_OPT_WRAPPER", "0") == "1":
+        try:
+            from mcore_gdn_opt.gated_delta_rule import chunk_gated_delta_rule
+        except ImportError:
+            from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+    else:
+        from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 
     HAVE_FLA = True
 except ImportError:

--- a/tests/unit_tests/ssm/bench_gdn_cuda_opt.py
+++ b/tests/unit_tests/ssm/bench_gdn_cuda_opt.py
@@ -1,0 +1,459 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Direct GatedDeltaNet CUDA optimization correctness and performance runner.
+
+This runner intentionally uses installed packages and normal project imports.
+Install `mcore_gdn_opt` and FLA in editable mode before running it.
+"""
+
+import argparse
+import importlib.util
+import os
+import statistics
+from contextlib import nullcontext
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from megatron.core import parallel_state
+from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+    get_experimental_attention_variant_module_spec,
+)
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+FLAGS = (
+    "MCORE_GDN_USE_OPT_WRAPPER",
+    "MCORE_GDN_OPT_BACKEND",
+    "MCORE_GDN_OPT_WARN_FALLBACK",
+    "MCORE_GDN_OPT_ENABLE_FWD_H",
+    "MCORE_GDN_OPT_ENABLE_WY_BWD",
+    "MCORE_GDN_OPT_ENABLE_DV_DHU",
+    "MCORE_GDN_OPT_ENABLE_DHU",
+    "MCORE_GDN_OPT_ENABLE_DQKWG",
+    "FLA_CUTE_FWD_H",
+    "CHUNK_DELTA_FWD_USE_BWD_PORT",
+    "FLA_CUTE_WY_BWD",
+    "FLA_CUTE_BWD_DV_DHU",
+    "FLA_CUTE_BWD_DHU",
+    "FLA_CUTE_BWD_DQKWG",
+)
+
+
+SCENARIOS = {
+    "baseline": ("Triton baseline", {}),
+    "wrapper_fla": (
+        "MCore wrapper forced FLA",
+        {"MCORE_GDN_USE_OPT_WRAPPER": "1", "MCORE_GDN_OPT_BACKEND": "fla"},
+    ),
+    "wrapper_auto": (
+        "MCore wrapper auto",
+        {"MCORE_GDN_USE_OPT_WRAPPER": "1", "MCORE_GDN_OPT_BACKEND": "auto"},
+    ),
+    "wrapper_cuda": (
+        "MCore wrapper forced CUDA",
+        {"MCORE_GDN_USE_OPT_WRAPPER": "1", "MCORE_GDN_OPT_BACKEND": "cuda"},
+    ),
+    "wy": (
+        "CUDA wy_bwd",
+        {
+            "MCORE_GDN_USE_OPT_WRAPPER": "1",
+            "MCORE_GDN_OPT_BACKEND": "cuda",
+            "MCORE_GDN_OPT_ENABLE_FWD_H": "0",
+            "MCORE_GDN_OPT_ENABLE_DV_DHU": "0",
+            "MCORE_GDN_OPT_ENABLE_DHU": "0",
+            "MCORE_GDN_OPT_ENABLE_DQKWG": "0",
+        },
+    ),
+    "dv_dhu": (
+        "CUDA dv_local+delta_h fused",
+        {
+            "MCORE_GDN_USE_OPT_WRAPPER": "1",
+            "MCORE_GDN_OPT_BACKEND": "cuda",
+            "MCORE_GDN_OPT_ENABLE_FWD_H": "0",
+            "MCORE_GDN_OPT_ENABLE_WY_BWD": "0",
+            "MCORE_GDN_OPT_ENABLE_DHU": "0",
+            "MCORE_GDN_OPT_ENABLE_DQKWG": "0",
+        },
+    ),
+    "dhu": (
+        "CUDA delta_h",
+        {
+            "MCORE_GDN_USE_OPT_WRAPPER": "1",
+            "MCORE_GDN_OPT_BACKEND": "cuda",
+            "MCORE_GDN_OPT_ENABLE_FWD_H": "0",
+            "MCORE_GDN_OPT_ENABLE_WY_BWD": "0",
+            "MCORE_GDN_OPT_ENABLE_DV_DHU": "0",
+            "MCORE_GDN_OPT_ENABLE_DQKWG": "0",
+        },
+    ),
+    "dqkwg": (
+        "CUDA dqkwg",
+        {
+            "MCORE_GDN_USE_OPT_WRAPPER": "1",
+            "MCORE_GDN_OPT_BACKEND": "cuda",
+            "MCORE_GDN_OPT_ENABLE_FWD_H": "0",
+            "MCORE_GDN_OPT_ENABLE_WY_BWD": "0",
+            "MCORE_GDN_OPT_ENABLE_DV_DHU": "0",
+            "MCORE_GDN_OPT_ENABLE_DHU": "0",
+        },
+    ),
+    "separate": (
+        "CUDA all three separate",
+        {
+            "MCORE_GDN_USE_OPT_WRAPPER": "1",
+            "MCORE_GDN_OPT_BACKEND": "cuda",
+            "MCORE_GDN_OPT_ENABLE_FWD_H": "0",
+            "MCORE_GDN_OPT_ENABLE_DV_DHU": "0",
+        },
+    ),
+    "dv_dhu_dqkwg": (
+        "CUDA fused_dv_dhu+dqkwg",
+        {
+            "MCORE_GDN_USE_OPT_WRAPPER": "1",
+            "MCORE_GDN_OPT_BACKEND": "cuda",
+            "MCORE_GDN_OPT_ENABLE_FWD_H": "0",
+            "MCORE_GDN_OPT_ENABLE_WY_BWD": "0",
+            "MCORE_GDN_OPT_ENABLE_DHU": "0",
+        },
+    ),
+    "all_four": (
+        "CUDA fwd_h+wy_bwd+dhu+dqkwg",
+        {
+            "MCORE_GDN_USE_OPT_WRAPPER": "1",
+            "MCORE_GDN_OPT_BACKEND": "cuda",
+            "MCORE_GDN_OPT_ENABLE_DV_DHU": "0",
+        },
+    ),
+    "fwd_h_wy_dv_dhu_dqkwg": (
+        "CUDA fwd_h+wy_bwd+fused_dv_dhu+dqkwg",
+        {
+            "MCORE_GDN_USE_OPT_WRAPPER": "1",
+            "MCORE_GDN_OPT_BACKEND": "cuda",
+            "MCORE_GDN_OPT_ENABLE_DHU": "0",
+        },
+    ),
+}
+
+
+@dataclass
+class AccuracyRow:
+    name: str
+    status: str
+    output_max_abs: float
+    input_grad_max_abs: float
+    worst_param: str
+    worst_param_max_abs: float
+
+
+@dataclass
+class PerfRow:
+    name: str
+    mean_us: float
+    median_us: float
+    min_us: float
+    max_us: float
+    speedup: float
+
+
+def set_env(overrides):
+    for flag in FLAGS:
+        os.environ.pop(flag, None)
+    if "MCORE_GDN_USE_OPT_WRAPPER" not in overrides:
+        os.environ["MCORE_GDN_USE_OPT_WRAPPER"] = "0"
+    if "MCORE_GDN_OPT_BACKEND" not in overrides:
+        os.environ["MCORE_GDN_OPT_BACKEND"] = "fla"
+    os.environ.update(overrides)
+
+
+def set_model_dispatch(model):
+    if os.environ.get("MCORE_GDN_USE_OPT_WRAPPER", "0") == "1":
+        from mcore_gdn_opt.gated_delta_rule import chunk_gated_delta_rule
+    else:
+        from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+
+    model.gated_delta_rule = chunk_gated_delta_rule
+
+
+def validate_dispatch_sources(scenario_items):
+    if any("MCORE_GDN_OPT_BACKEND" in env for _, (_, env) in scenario_items):
+        for module_name in (
+            "mcore_gdn_opt.gated_delta_rule.chunk",
+            "mcore_gdn_opt.gated_delta_rule.backward",
+        ):
+            spec = importlib.util.find_spec(module_name)
+            if spec is None or spec.origin is None:
+                raise RuntimeError(f"cannot locate required mcore_gdn_opt module {module_name!r}")
+            print(
+                f"MCORE_GDN_OPT_DISPATCH_SOURCE module={module_name} path={spec.origin}", flush=True
+            )
+
+
+def nvtx_range(label, enabled=True):
+    if enabled and torch.cuda.is_available():
+        return torch.cuda.nvtx.range(label)
+    return nullcontext()
+
+
+def scenario_label(index, name):
+    safe_name = name.replace(" ", "_").replace("+", "plus").replace("/", "_")
+    return f"gdn_only/{index:02d}_{safe_name}"
+
+
+def make_model(dtype):
+    from megatron.core.ssm.gated_delta_net import GatedDeltaNet
+
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, context_parallel_size=1
+    )
+    model_parallel_cuda_manual_seed(123)
+    pg_collection = ProcessGroupCollection(
+        tp=parallel_state.get_tensor_model_parallel_group(),
+        cp=parallel_state.get_context_parallel_group(),
+    )
+    cfg = TransformerConfig(
+        hidden_size=128,
+        linear_conv_kernel_dim=2,
+        linear_key_head_dim=128,
+        linear_value_head_dim=128,
+        linear_num_key_heads=64,
+        linear_num_value_heads=64,
+        num_layers=1,
+        normalization="RMSNorm",
+        use_cpu_initialization=True,
+        layernorm_zero_centered_gamma=True,
+        num_attention_heads=64,
+        activation_func=F.silu,
+        bf16=(dtype == torch.bfloat16),
+        fp16=(dtype == torch.float16),
+        experimental_attention_variant="gated_delta_net",
+        linear_attention_freq=[1],
+        transformer_impl="transformer_engine",
+    )
+    submodules = get_experimental_attention_variant_module_spec(config=cfg).submodules
+    return (
+        GatedDeltaNet(
+            cfg,
+            submodules=submodules,
+            layer_number=1,
+            bias=False,
+            conv_bias=False,
+            conv_init=1.0,
+            use_qk_l2norm=True,
+            A_init_range=(1, 16),
+            pg_collection=pg_collection,
+        )
+        .cuda()
+        .to(dtype)
+    )
+
+
+def zero_grads(model):
+    model.zero_grad(set_to_none=True)
+
+
+def compute_loss(output, loss):
+    if loss == "sum":
+        return output.float().sum()
+    if loss == "square_mean":
+        return output.float().square().mean()
+    raise ValueError(f"unknown loss: {loss}")
+
+
+def run_once(model, x, env, loss, nvtx_label=None, use_nvtx=True):
+    set_env(env)
+    set_model_dispatch(model)
+    print(
+        "RUN_ONCE "
+        f"label={nvtx_label or 'none'} "
+        f"use_wrapper={os.environ.get('MCORE_GDN_USE_OPT_WRAPPER', '')} "
+        f"backend={os.environ.get('MCORE_GDN_OPT_BACKEND', '')}",
+        flush=True,
+    )
+    zero_grads(model)
+    inp = x.detach().clone().requires_grad_(True)
+    with nvtx_range(nvtx_label, enabled=use_nvtx and nvtx_label is not None):
+        out, _ = model(inp, attention_mask=None)
+        compute_loss(out, loss).backward()
+    torch.cuda.synchronize()
+    grads = {
+        name: param.grad.detach().float().clone().cpu()
+        for name, param in model.named_parameters()
+        if param.grad is not None
+    }
+    return out.detach().float().clone().cpu(), inp.grad.detach().float().clone().cpu(), grads
+
+
+def diff_max_abs(actual, expected):
+    return float((actual - expected).abs().max().item())
+
+
+def allclose(actual, expected, atol, rtol):
+    return bool(torch.isfinite(actual).all().item()) and bool(
+        torch.allclose(actual, expected, atol=atol, rtol=rtol)
+    )
+
+
+def check_accuracy(model, x, scenario_items, loss, atol, rtol, use_nvtx=True):
+    base_name, base_env = SCENARIOS["baseline"]
+    base_out, base_grad, base_params = run_once(
+        model, x, base_env, loss, "gdn_only/00_accuracy_reference/Triton_baseline", use_nvtx
+    )
+    rows = []
+    for scenario_idx, (_, (name, env)) in enumerate(scenario_items, start=1):
+        label = f"{scenario_label(scenario_idx, name)}/accuracy"
+        out, grad, params = run_once(model, x, env, loss, label, use_nvtx)
+        output_ok = allclose(out, base_out, atol, rtol)
+        grad_ok = allclose(grad, base_grad, atol, rtol)
+        worst_param = ""
+        worst_param_abs = 0.0
+        params_ok = True
+        for param_name, expected in base_params.items():
+            actual = params[param_name]
+            params_ok = params_ok and allclose(actual, expected, atol, rtol)
+            param_abs = diff_max_abs(actual, expected)
+            if param_abs > worst_param_abs:
+                worst_param = param_name
+                worst_param_abs = param_abs
+        rows.append(
+            AccuracyRow(
+                name=name,
+                status="PASS" if output_ok and grad_ok and params_ok else "FAIL",
+                output_max_abs=diff_max_abs(out, base_out),
+                input_grad_max_abs=diff_max_abs(grad, base_grad),
+                worst_param=worst_param,
+                worst_param_max_abs=worst_param_abs,
+            )
+        )
+    return rows
+
+
+def fwd_bwd(model, x, env, loss, nvtx_label=None, use_nvtx=True):
+    set_env(env)
+    set_model_dispatch(model)
+    zero_grads(model)
+    inp = x.detach().requires_grad_(True)
+    with nvtx_range(nvtx_label, enabled=use_nvtx and nvtx_label is not None):
+        out, _ = model(inp, attention_mask=None)
+        compute_loss(out, loss).backward()
+
+
+def benchmark(model, x, scenario_items, loss, warmup, repeats, rounds, use_nvtx=True):
+    rows = []
+    baseline_us = None
+    for scenario_idx, (_, (name, env)) in enumerate(scenario_items, start=1):
+        base_label = scenario_label(scenario_idx, name)
+        for warmup_idx in range(warmup):
+            fwd_bwd(model, x, env, loss, f"{base_label}/warmup_{warmup_idx:02d}", use_nvtx)
+        torch.cuda.synchronize()
+        samples = []
+        for round_idx in range(rounds):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            with nvtx_range(
+                f"{base_label}/round_{round_idx:02d}/measured_{repeats}iters", enabled=use_nvtx
+            ):
+                start.record()
+                for iter_idx in range(repeats):
+                    fwd_bwd(
+                        model,
+                        x,
+                        env,
+                        loss,
+                        f"{base_label}/round_{round_idx:02d}/iter_{iter_idx:02d}",
+                        use_nvtx,
+                    )
+                end.record()
+            torch.cuda.synchronize()
+            samples.append(start.elapsed_time(end) * 1000.0 / repeats)
+        mean_us = statistics.mean(samples)
+        if baseline_us is None:
+            baseline_us = mean_us
+        rows.append(
+            PerfRow(
+                name=name,
+                mean_us=mean_us,
+                median_us=statistics.median(samples),
+                min_us=min(samples),
+                max_us=max(samples),
+                speedup=baseline_us / mean_us,
+            )
+        )
+    return rows
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dtype", choices=("bf16", "fp16"), default="bf16")
+    parser.add_argument("--loss", choices=("sum", "square_mean"), default="square_mean")
+    parser.add_argument("--scenarios", default="baseline,separate,all_four,fwd_h_wy_dv_dhu_dqkwg")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--atol", type=float, default=5e-3)
+    parser.add_argument("--rtol", type=float, default=5e-3)
+    parser.add_argument("--fail-on-accuracy", action="store_true")
+    parser.add_argument("--no-nvtx", dest="use_nvtx", action="store_false", default=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    keys = [key.strip() for key in args.scenarios.split(",") if key.strip()]
+    if "baseline" not in keys:
+        keys.insert(0, "baseline")
+    unknown = [key for key in keys if key not in SCENARIOS]
+    if unknown:
+        raise ValueError(f"unknown scenarios: {unknown}; choices={sorted(SCENARIOS)}")
+    scenario_items = [(key, SCENARIOS[key]) for key in keys]
+    validate_dispatch_sources(scenario_items)
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+
+    torch.manual_seed(123)
+    set_env({})
+    print(
+        f"DEVICE {torch.cuda.get_device_name(0)} SHAPE B=2 T=8192 H=64 D=128 "
+        f"dtype={args.dtype} loss={args.loss}"
+    )
+    try:
+        model = make_model(dtype).eval()
+        x = torch.randn(8192, 2, 128, device="cuda", dtype=dtype)
+        accuracy_rows = check_accuracy(
+            model, x, scenario_items, args.loss, args.atol, args.rtol, args.use_nvtx
+        )
+        for row in accuracy_rows:
+            print(
+                f"ACCURACY name={row.name!r} status={row.status} "
+                f"output_max_abs={row.output_max_abs:.9f} "
+                f"input_grad_max_abs={row.input_grad_max_abs:.9f} "
+                f"worst_param={row.worst_param} "
+                f"worst_param_max_abs={row.worst_param_max_abs:.9f}"
+            )
+        perf_rows = benchmark(
+            model,
+            x,
+            scenario_items,
+            args.loss,
+            args.warmup,
+            args.repeats,
+            args.rounds,
+            args.use_nvtx,
+        )
+        for row in perf_rows:
+            print(
+                f"PERF name={row.name!r} mean_us={row.mean_us:.3f} "
+                f"median_us={row.median_us:.3f} min_us={row.min_us:.3f} "
+                f"max_us={row.max_us:.3f} speedup_vs_baseline={row.speedup:.3f}"
+            )
+        if args.fail_on_accuracy and any(row.status != "PASS" for row in accuracy_rows):
+            raise SystemExit(1)
+    finally:
+        set_env({})
+        Utils.destroy_model_parallel()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/ssm/test_bench_gdn_cuda_opt_scenarios.py
+++ b/tests/unit_tests/ssm/test_bench_gdn_cuda_opt_scenarios.py
@@ -1,0 +1,56 @@
+import ast
+from pathlib import Path
+
+BENCH = Path(__file__).with_name("bench_gdn_cuda_opt.py")
+
+
+def _literal_assignment(name):
+    tree = ast.parse(BENCH.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} assignment not found")
+
+
+def test_optimized_scenarios_route_through_mcore_wrapper():
+    scenarios = _literal_assignment("SCENARIOS")
+    optimized = [
+        "wy",
+        "dv_dhu",
+        "dhu",
+        "dqkwg",
+        "separate",
+        "dv_dhu_dqkwg",
+        "all_four",
+        "fwd_h_wy_dv_dhu_dqkwg",
+    ]
+
+    for key in optimized:
+        env = scenarios[key][1]
+        assert env["MCORE_GDN_USE_OPT_WRAPPER"] == "1", key
+        assert env["MCORE_GDN_OPT_BACKEND"] == "cuda", key
+        assert not any(flag.startswith("FLA_CUTE_") for flag in env), key
+
+
+def test_benchmark_does_not_require_patched_fla_sources():
+    text = BENCH.read_text()
+
+    assert "patched flash-linear-attention" not in text
+    assert "FLA_DISPATCH_SOURCE" not in text
+
+
+def test_benchmark_does_not_expose_dhu_dqkwg_wrapper_path():
+    scenarios = _literal_assignment("SCENARIOS")
+    flags = _literal_assignment("FLAGS")
+    forbidden = {
+        "MCORE_GDN_OPT_ENABLE_DHU_DQKWG",
+        "FLA_CUTE_BWD_DHU_DQKWG",
+        "FLA_CUTE_BWD_DHU_DQKWG_KERNEL",
+        "FLA_CUTE_BWD_DHU_DQKWG_DIRECT",
+    }
+
+    assert forbidden.isdisjoint(flags)
+    for key, (_label, env) in scenarios.items():
+        assert forbidden.isdisjoint(env), key

--- a/tests/unit_tests/ssm/test_gated_delta_net_cuda_opt.py
+++ b/tests/unit_tests/ssm/test_gated_delta_net_cuda_opt.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Focused GatedDeltaNet CUDA optimization coverage.
+
+This keeps the optimized-kernel correctness and optional perf check separate
+from the generic GatedDeltaNet unit tests.
+"""
+
+import os
+
+import pytest
+import torch
+
+from tests.unit_tests.ssm import bench_gdn_cuda_opt as runner
+
+try:
+    import fla  # noqa: F401
+
+    HAVE_FLA = True
+except ImportError:
+    HAVE_FLA = False
+
+
+def _scenario_items():
+    keys = [
+        key.strip()
+        for key in os.environ.get(
+            "MCORE_GDN_UNIT_TEST_SCENARIOS", "baseline,fwd_h_wy_dv_dhu_dqkwg"
+        ).split(",")
+        if key.strip()
+    ]
+    if "baseline" not in keys:
+        keys.insert(0, "baseline")
+    unknown = [key for key in keys if key not in runner.SCENARIOS]
+    if unknown:
+        raise ValueError(f"unknown GDN CUDA opt scenarios: {unknown}")
+    return [(key, runner.SCENARIOS[key]) for key in keys]
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not HAVE_FLA, reason="FLA is not installed.")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available.")
+@pytest.mark.internal
+def test_gated_delta_net_cuda_opt_correctness_and_optional_perf(dtype):
+    scenario_items = _scenario_items()
+    runner.validate_dispatch_sources(scenario_items)
+
+    torch.manual_seed(123)
+    runner.set_env({})
+    try:
+        model = runner.make_model(dtype).eval()
+        seq_len = int(os.environ.get("MCORE_GDN_UNIT_TEST_T", "8192"))
+        batch = int(os.environ.get("MCORE_GDN_UNIT_TEST_B", "2"))
+        x = torch.randn(seq_len, batch, 128, device="cuda", dtype=dtype)
+
+        atol = float(os.environ.get("MCORE_GDN_UNIT_TEST_ATOL", "5e-3"))
+        rtol = float(os.environ.get("MCORE_GDN_UNIT_TEST_RTOL", "5e-3"))
+        loss = os.environ.get("MCORE_GDN_UNIT_TEST_LOSS", "sum")
+        accuracy_rows = runner.check_accuracy(
+            model, x, scenario_items, loss=loss, atol=atol, rtol=rtol, use_nvtx=False
+        )
+        failed = [row for row in accuracy_rows if row.status != "PASS"]
+        assert not failed, "\n".join(
+            f"{row.name}: output={row.output_max_abs:.9f} "
+            f"input_grad={row.input_grad_max_abs:.9f} "
+            f"{row.worst_param}={row.worst_param_max_abs:.9f}"
+            for row in failed
+        )
+
+        if os.environ.get("MCORE_GDN_UNIT_TEST_PERF", "0") == "1":
+            perf_rows = runner.benchmark(
+                model,
+                x,
+                scenario_items,
+                loss=loss,
+                warmup=int(os.environ.get("MCORE_GDN_UNIT_TEST_WARMUP", "5")),
+                repeats=int(os.environ.get("MCORE_GDN_UNIT_TEST_REPEATS", "20")),
+                rounds=int(os.environ.get("MCORE_GDN_UNIT_TEST_ROUNDS", "3")),
+                use_nvtx=True,
+            )
+            for row in perf_rows:
+                print(
+                    f"PERF {row.name}: mean_us={row.mean_us:.3f} "
+                    f"speedup_vs_baseline={row.speedup:.3f}"
+                )
+    finally:
+        runner.set_env({})
+        runner.Utils.destroy_model_parallel()


### PR DESCRIPTION
# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact the @mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment the [@mcore-oncall](https://github.com/orgs/NVIDIA/teams/mcore-oncall) to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.

<details>
<summary>For MRs into `dev` branch</summary>
The proposed review process for `dev` branch is under active discussion.

MRs are mergable after one approval by either `eharper@nvidia.com` or `zijiey@nvidia.com`.
</details>

## Summary by Sourcery

Add an optional environment-controlled GatedDeltaNet wrapper that can route gated-delta-rule calls through an external CUDA-optimized package and introduce dedicated benchmarks, tests, and docs for validating its correctness and performance.

New Features:
- Allow GatedDeltaNet to use an optional mcore_gdn_opt-based gated-delta-rule implementation via an environment flag fallback to the existing FLA path.

Enhancements:
- Add a standalone GatedDeltaNet CUDA optimization benchmark runner covering multiple runtime scenarios and NVTX-instrumented performance measurements.

Documentation:
- Document the setup and workflow for reproducing GatedDeltaNet CUDA optimizations, including installation, runtime flags, tests, and Nsight profiling steps.

Tests:
- Add pytest coverage that reuses the benchmark runner to validate optimized GatedDeltaNet kernels against a Triton baseline with configurable scenarios and optional performance reporting.
- Add regression tests to ensure benchmark scenarios consistently route through the mcore wrapper and do not rely on patched FLA sources or unsupported fused paths.