### PR TITLE
Support discard-output recompute for MoE shared experts under A2A overlap

### DIFF
--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -634,6 +634,14 @@ def build_transformer_layer_callables(layer: TransformerLayer):
             # as a gradient hook of expert_output
             layer.pre_mlp_norm_checkpoint.discard_output_and_register_recompute(expert_output)
 
+        # Trigger the shared-expert recompute from expert_output too (output freed in
+        # submodule_combine_forward). Registering on the same tensor AFTER the pre_mlp_norm
+        # recompute orders it after pre_mlp_layernorm_output is restored and before the attn node's
+        # shared-expert backward.
+        shared_experts_checkpoint = getattr(layer.mlp, "shared_experts_checkpoint", None)
+        if shared_experts_checkpoint is not None:
+            shared_experts_checkpoint.register_recompute_hook(expert_output)
+
         return expert_output
 
     def submodule_combine_forward(node: ScheduleNode, output: torch.Tensor):
@@ -683,6 +691,13 @@ def build_transformer_layer_callables(layer: TransformerLayer):
         if not node.is_mtp and final_layernorm and node.is_last_layer:
             output = final_layernorm(output)
             output = make_viewless_tensor(inp=output, requires_grad=True, keep_graph=True)
+
+        # postprocess() has consumed the shared-expert output; free its storage now (the recompute
+        # hook was registered on expert_output in submodule_moe_forward).
+        shared_experts_checkpoint = getattr(layer.mlp, "shared_experts_checkpoint", None)
+        if shared_experts_checkpoint is not None:
+            shared_experts_checkpoint.discard_output()
+            layer.mlp.shared_experts_checkpoint = None
         return output
 
     @copy_signature(layer._forward_mlp, handle_first_dst_param='preserve')

--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -914,6 +914,35 @@ class CheckpointWithoutOutput(object):
         self.outputs = None
         self.ctx = None
 
+    def discard_output(self):
+        """Free the output storages (metadata kept for backward).
+
+        Pair with :meth:`register_recompute_hook` when the output is freed in a different place
+        than where the recompute hook is registered; otherwise use
+        :meth:`discard_output_and_register_recompute`.
+        """
+        from megatron.core.transformer.cuda_graphs import is_graph_warmup
+
+        if self.ckpt_manager is not None or is_graph_warmup():
+            return
+        # resize keeps tensor metadata (needed for backward) while releasing the memory.
+        for output in self.outputs:
+            output.untyped_storage().resize_(0)
+
+    def register_recompute_hook(self, hook_tensor):
+        """Trigger the recompute from ``hook_tensor``'s grad hook.
+
+        ``hook_tensor`` must have its grad computed before the discarded outputs are needed in
+        backward (and, if the recompute reads other discarded activations, after those are
+        restored).
+        """
+        from megatron.core.transformer.cuda_graphs import is_graph_warmup
+
+        if self.ckpt_manager is not None or is_graph_warmup():
+            return
+        if hook_tensor.requires_grad:
+            hook_tensor.register_hook(self._recompute)
+
     def discard_output_and_register_recompute(self, hook_tensor):
         """
         Release the output tensor storages and register the recompute function as a grad hook of
@@ -923,21 +952,5 @@ class CheckpointWithoutOutput(object):
         in the forward pass and the gradient of the hook_tensor is computed before the recomputed
         tensors are used.
         """
-        # When ckpt_manager is set, this is a no-op.
-        # Manager handles all discarding and hook registration uniformly.
-        from megatron.core.transformer.cuda_graphs import is_graph_warmup
-
-        if self.ckpt_manager is not None or is_graph_warmup():
-            return
-
-        # use resize to release the output tensor memory and still keep the metadata in the tensors.
-        # the metadata is still needed for backward
-        for output in self.outputs:
-            output.untyped_storage().resize_(0)
-
-        # register the recomputation as a backward hook, when the the gradient of the hook_tensor
-        # is computed, the recomputation will be triggered. The hook_tensor should be selected
-        # carefully to ensure that the tensors are recomputed before it is used by other backward
-        # computations.
-        if hook_tensor.requires_grad:
-            hook_tensor.register_hook(self._recompute)
+        self.discard_output()
+        self.register_recompute_hook(hook_tensor)

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -243,6 +243,18 @@ class MoELayer(BaseMoELayer):
             config.recompute_granularity == 'selective'
             and "shared_experts" in config.recompute_modules
         )
+        # Discard the shared-expert OUTPUT (CheckpointWithoutOutput) instead of a standard
+        # checkpoint that keeps it. The recompute is wired up where ordering is correct (after any
+        # pre_mlp_layernorm recompute) by the caller: the fine-grained callables for A2A overlap,
+        # or TransformerLayer._forward_post_mlp otherwise. Disabled under MoE cudagraph partial
+        # capture, where the output is a graph output and must keep its storage.
+        self.shared_experts_recompute_discard_output = (
+            self.shared_experts_recompute
+            and not bool(getattr(config, "cuda_graph_modules", None))
+        )
+        # The active CheckpointWithoutOutput, handed to the caller that frees the output and
+        # registers the recompute hook (None when not using discard-output recompute).
+        self.shared_experts_checkpoint = None
 
         self.tp_group = pg_collection.tp
         self.tp_ep_group = pg_collection.tp_ep
@@ -530,7 +542,19 @@ class MoELayer(BaseMoELayer):
         shared_expert_output = None
         if self.use_shared_expert and not self.shared_expert_overlap:
             # Compute the shared expert separately when not overlapped with communication.
-            if self.shared_experts_recompute:
+            if self.shared_experts_recompute_discard_output and self.training:
+                # Recompute-with-discarded-output: run the shared expert under no_grad, then free
+                # its output in postprocess() and regenerate it (with its backward graph) from a
+                # grad hook. CheckpointWithoutOutput handles fp8/fp4 internally via its fp8 flag.
+                self.shared_experts_checkpoint = tensor_parallel.CheckpointWithoutOutput(
+                    fp8=(self.config.fp8 or self.config.fp4)
+                )
+                shared_expert_output = self.shared_experts_checkpoint.checkpoint(
+                    apply_module(self.shared_experts), hidden_states
+                )
+            elif self.shared_experts_recompute:
+                # Standard checkpoint fallback (e.g. MoE cudagraph partial capture or eval): keep
+                # the output, recompute only the intermediates.
                 if self.config.fp8 or self.config.fp4:
                     shared_expert_output = te_checkpoint(
                         apply_module(self.shared_experts),

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -904,6 +904,19 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 mlp_output_with_bias[0]
             )
 
+        # Shared-expert discard-output recompute (non-overlap path; the A2A-overlap path uses the
+        # fine-grained callables and never reaches here). The output was consumed by the MoE
+        # postprocess add, so free it and register the recompute on mlp_output_with_bias[0] AFTER
+        # the pre_mlp_norm recompute above (same hook tensor) — this orders it after the shared
+        # expert's input pre_mlp_layernorm_output is restored and before its backward.
+        if self.is_moe_layer:
+            shared_experts_checkpoint = getattr(self.mlp, "shared_experts_checkpoint", None)
+            if shared_experts_checkpoint is not None:
+                shared_experts_checkpoint.discard_output_and_register_recompute(
+                    mlp_output_with_bias[0]
+                )
+                self.mlp.shared_experts_checkpoint = None
+
         # TODO: could we move `bias_dropout_add_exec_handler` itself
         # inside the module provided in the `bias_dropout_add_spec` module?
         nvtx_range_push(suffix="mlp_bda")

--- a/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
@@ -74,9 +74,12 @@ class TestFSDP1F1BOverlap:
         [[], ["attn_norm", "core_attn", "attn_proj", "mlp_norm", "expert_fc1", "moe_act"]],
     )
     def test_fsdp_1f1b_memory_opt(self, recompute_modules, offload_modules):
+        # Configure shared experts so recompute_modules=[..., "shared_experts"] actually
+        # exercises the shared-experts discard-output recompute (a no-op without them).
         self._run_test_helper(
             dispatcher_type="alltoall",
             sharding_strategy="optim_grads_params",
+            shared_expert_intermediate_size=512,
             recompute_modules=recompute_modules,
             offload_modules=offload_modules,
         )


### PR DESCRIPTION

<img width="2566" height="326" alt="image" src="https://github.com/user-attachments/assets/efdf2836-9f62-4c8f-afbd-d419fdeece31" />

## What

Switches `shared_experts` selective recompute from a standard checkpoint (which keeps the output activation) to `CheckpointWithoutOutput`: the shared-expert **output** activation is discarded in the forward and regenerated in backward from a grad hook. Supported on **both** the A2A-overlap (fine-grained callables) and the single-call (non-overlap) MoE paths.

- `tensor_parallel/random.py`: split `CheckpointWithoutOutput.discard_output_and_register_recompute` into `discard_output()` + `register_recompute_hook()` so the output can be freed and the recompute hook registered at different points.
- `moe/moe_layer.py`: `shared_experts_compute` uses `CheckpointWithoutOutput` when discard-output recompute is enabled (gated only off MoE cudagraph partial capture, where the shared-expert output is a graph output that must keep its storage).
- `models/gpt/fine_grained_callables.py` (**A2A-overlap path**): register the recompute on the **moe node's `expert_output`** (right after the `pre_mlp_norm` recompute, same tensor) and free the output in the **combine node** after `postprocess()` consumes it.
- `transformer/transformer_layer.py` (**non-overlap path**): in `_forward_post_mlp`, free the output and register the recompute on **`mlp_output_with_bias[0]`** right after the `pre_mlp_norm` recompute.

## Ordering invariant (both paths)

The shared expert's input is `pre_mlp_layernorm_output`, which the `layernorm` recompute discards and only restores in its own backward hook. So the shared-expert recompute must fire **after** the `pre_mlp_norm` recompute (input restored) and **before** the shared expert's backward. Both paths register the hook on the same tensor as — and immediately after — `pre_mlp_norm`, guaranteeing the order. A hook placed too early (e.g. on the combine node output, which detaches between schedule nodes) hits a freed `pre_mlp_layernorm_output` → cuBLAS error. The two paths are mutually exclusive (overlap bypasses `_forward_post_mlp`; non-overlap bypasses the fine-grained callables), so there is no double registration.

## Memory savings

Discard-output frees one extra activation that a standard checkpoint retains: the shared-expert **output**, shape `[seq, mbs, hidden]` (~0.5 GB/MoE-layer at seq=4096, hidden=4096, bf16, mbs=4). The realized **peak** saving is smaller than the per-layer × num-layers sum because only the few layers whose shared-expert output is co-resident at the instantaneous peak (bwd → optimizer) are freed.

Controlled measurement on the Qwen3.5-VL 397B proxy (8×GB200, EP=8, mbs=4, full stack: `layernorm + gdn_norm_out + moe_act + shared_experts` recompute + offload + precision-aware optimizer + A2A overlap) — same recipe, the only difference is the shared_experts checkpoint mechanism:

| shared_experts recompute | peak max_allocated |
|---|---|
| standard checkpoint (keeps output) | 85.94 GB |
| **discard-output (this PR)** | **84.75 GB** |
| **saving** | **−1.19 GB** |

Notes:
- This is an **incremental** saving on top of an already-recompute+offload stack (standard checkpoint already recomputes the shared-expert *intermediates*; this PR additionally frees the *output*). It is not a large single-point reduction.
- The saving scales ~linearly with `micro_batch_size` (output ∝ mbs) and with how many layers' shared-expert outputs are co-resident at the peak.
- Its main value is bringing the shared expert into the same discard-output recompute scheme as `layernorm` / `gdn_norm_out`, rather than a large standalone win.

## Validation (Qwen3.5-VL 397B proxy, 8×GB200, EP=8, mbs=4, multimodal entry)

Full stack, 20 iters (10 for non-overlap), stable loss, no NaN:

| path | result |
|---|---|
| A2A overlap (+ offload + paopt) | 20 iters clean, 84.75 GB max_alloc |
| non-overlap | 10 iters clean (functional; no offload/paopt in this run) |
| isolated (`recompute_modules=[shared_experts]`, no layernorm nesting) | 20 iters clean |

### Numerical parity (3-way, same seed=1234, A2A overlap on, mbs=4)

**REF** (shared_experts NOT recomputed) vs **TEST** (discard-output) vs **REF-dup** (REF re-run, FP-noise floor), per-iter `lm loss`:

| iter | REF | TEST | REF-dup | \|REF−TEST\| | \|REF−dup\| |
|---|---|---|---|---|---|
| 1 | 13.24673 | 13.24672 | 13.24665 | 1e-5 | 8e-5 |
| 5 | 13.23938 | 13.23925 | 13.23932 | 1.3e-4 | 6e-5 |
| 6 | 13.24373 | 13.24389 | 13.24388 | 1.6e-4 | 1.5e-4 |
| 10 | 13.24379 | 13.24394 | 13.24366 | 1.5e-4 | 1.3e-4 |

`|REF − TEST|` is the same magnitude as the `|REF − REF-dup|` non-determinism floor with no systematic drift; grad norms match to 3 digits. So discard-output recompute is numerically equivalent to not recomputing, within run-to-run FP noise. (Bitwise-deterministic comparison isn't possible: SM100 attention backward with head_dim=256 has no deterministic kernel, so `--deterministic-mode` asserts out for this model.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)