### PR TITLE
Add qk_rope discard-output recompute + activation offload for split_qkv RoPE

### DIFF
--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -363,6 +363,27 @@ class Attention(MegatronModule, ABC):
             and "attn_proj" in self.config.offload_modules
         )
 
+        # qk_rope: discard-output recompute of the rotary embedding applied to query/key
+        # (split_qkv path). The rotated q/k are released after core attention and recomputed
+        # in backward. Combine with offload (below) to actually save GPU memory: recompute
+        # alone only swaps which same-sized tensor is kept (rope input vs output).
+        self.recompute_qk_rope = (
+            self.config.recompute_granularity == 'selective'
+            and "qk_rope" in self.config.recompute_modules
+        )
+
+        # qk_rope offload: offload the rope input (post-qk-norm q/k) to CPU. Only yields
+        # savings when combined with recompute_qk_rope, whose save_for_backward inputs are
+        # captured by this offload group (plain rope does not save its input for backward).
+        self.offload_qk_rope = (
+            self.config.fine_grained_activation_offloading
+            and "qk_rope" in self.config.offload_modules
+        )
+
+        # Per-forward CheckpointWithoutOutput handle for qk_rope discard-output recompute;
+        # set in forward, consumed (discard + recompute hook) right after core attention.
+        self.qk_rope_checkpoint = None
+
         # Output.
         self.linear_proj = build_module(
             submodules.linear_proj,
@@ -524,6 +545,35 @@ class Attention(MegatronModule, ABC):
             packed_seq_params=packed_seq_params,
             **extra_kwargs,
         )
+
+    def _apply_qk_rope(self, query, key, q_pos_emb, k_pos_emb, cu_seqlens_q, cu_seqlens_kv):
+        """Apply rotary position embedding to query/key for the split_qkv training path.
+
+        Factored out so the rope can be wrapped by ``CheckpointWithoutOutput`` (discard-output
+        recompute) and/or fine-grained activation offloading when ``qk_rope`` is in
+        ``recompute_modules`` / ``offload_modules``. Mirrors the static-batching rope inlined
+        in ``forward``; only used during training (inference keeps the inline path, which has
+        a separate ``inference_context.apply_rotary_emb_query`` branch).
+        """
+        if q_pos_emb is not None:
+            query = apply_rotary_pos_emb(
+                query,
+                q_pos_emb,
+                config=self.config,
+                cu_seqlens=cu_seqlens_q,
+                mscale=_yarn_get_concentration_factor_from_config(self.config),
+                cp_group=self.pg_collection.cp,
+            )
+        if k_pos_emb is not None:
+            key = apply_rotary_pos_emb(
+                key,
+                k_pos_emb,
+                config=self.config,
+                cu_seqlens=cu_seqlens_kv,
+                mscale=_yarn_get_concentration_factor_from_config(self.config),
+                cp_group=self.pg_collection.cp,
+            )
+        return query, key
 
     def _allocate_memory(self, inference_max_sequence_length, batch_size, dim, dtype):
         """Allocate memory to store kv cache during inference."""
@@ -1290,30 +1340,55 @@ class Attention(MegatronModule, ABC):
                 cu_seqlens_q = cu_seqlens_kv = None
 
             if split_qkv:
-                if q_pos_emb is not None:
-                    # TODO VIJAY: simplify
-                    if inference_context is None or inference_context.is_static_batching():
-                        query = apply_rotary_pos_emb(
-                            query,
-                            q_pos_emb,
+                if self.training and (self.recompute_qk_rope or self.offload_qk_rope):
+                    # qk_rope: optionally offload the rope input (post-qk-norm q/k) to CPU
+                    # and/or discard-output recompute the rotated q/k. The offload group
+                    # captures the CheckpointWithoutOutput save_for_backward inputs; the
+                    # rotated q/k are released after core attention and recomputed in
+                    # backward. Training-only; inference uses the inline path below.
+                    qk_rope_manager = off_interface(
+                        self.offload_qk_rope and self.training, query, "qk_rope"
+                    )
+
+                    def _qk_rope_fn(q, k):
+                        return self._apply_qk_rope(
+                            q, k, q_pos_emb, k_pos_emb, cu_seqlens_q, cu_seqlens_kv
+                        )
+
+                    with qk_rope_manager as query:
+                        if self.recompute_qk_rope:
+                            self.qk_rope_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+                            query, key = self.qk_rope_checkpoint.checkpoint(
+                                _qk_rope_fn, query, key
+                            )
+                        else:
+                            query, key = _qk_rope_fn(query, key)
+                    query, key = qk_rope_manager.group_offload((query, key))
+                else:
+                    if q_pos_emb is not None:
+                        # TODO VIJAY: simplify
+                        if inference_context is None or inference_context.is_static_batching():
+                            query = apply_rotary_pos_emb(
+                                query,
+                                q_pos_emb,
+                                config=self.config,
+                                cu_seqlens=cu_seqlens_q,
+                                mscale=_yarn_get_concentration_factor_from_config(self.config),
+                                cp_group=self.pg_collection.cp,
+                            )
+                        else:
+                            query = inference_context.apply_rotary_emb_query(
+                                query, q_pos_emb, self.config, cu_seqlens_q, self.pg_collection.cp
+                            )
+                    if k_pos_emb is not None:
+                        key = apply_rotary_pos_emb(
+                            key,
+                            k_pos_emb,
                             config=self.config,
-                            cu_seqlens=cu_seqlens_q,
+                            cu_seqlens=cu_seqlens_kv,
                             mscale=_yarn_get_concentration_factor_from_config(self.config),
                             cp_group=self.pg_collection.cp,
                         )
-                    else:
-                        query = inference_context.apply_rotary_emb_query(
-                            query, q_pos_emb, self.config, cu_seqlens_q, self.pg_collection.cp
-                        )
-                if k_pos_emb is not None:
-                    key = apply_rotary_pos_emb(
-                        key,
-                        k_pos_emb,
-                        config=self.config,
-                        cu_seqlens=cu_seqlens_kv,
-                        mscale=_yarn_get_concentration_factor_from_config(self.config),
-                        cp_group=self.pg_collection.cp,
-                    )
             else:
                 query, key, value = apply_fused_qkv_rotary_pos_emb(
                     mixed_qkv, q_pos_emb, k_pos_emb, qkv_split_arg_list
@@ -1393,6 +1468,14 @@ class Attention(MegatronModule, ABC):
             # note that batch is a dummy dimension in the packed case
             core_attn_out = core_attn_out.reshape(core_attn_out.size(0), 1, -1)
         nvtx_range_pop(suffix="core_attention")
+
+        if self.recompute_qk_rope and self.training and self.qk_rope_checkpoint is not None:
+            # The rotated q/k (qk_rope output) were saved by core attention for its backward.
+            # Discard them now and recompute via a grad hook on core_attn_out, whose gradient
+            # is produced (by the downstream proj/gate backward) before core attention's
+            # backward needs q/k -- so the rotation is restored just in time.
+            self.qk_rope_checkpoint.discard_output_and_register_recompute(core_attn_out)
+            self.qk_rope_checkpoint = None
 
         if head_wise_gate is not None:
             nvtx_range_push(suffix="head_wise_attn_gate")

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -543,7 +543,7 @@ class TransformerConfig(ModelParallelConfig):
     recompute_modules: Optional[List[str]] = None
     """The submodules to recompute.
     choices: "core_attn", "moe_act", "layernorm", "mla_up_proj", "mlp", "moe",
-             "shared_experts", "mhc", "gdn_norm_out".
+             "shared_experts", "mhc", "gdn_norm_out", "qk_rope".
     default: ["core_attn"].
     "core_attn": recompute the core attention part of the transformer layer.
     "moe_act": recompute the MoE MLP activation function.
@@ -556,8 +556,13 @@ class TransformerConfig(ModelParallelConfig):
             CheckpointWithoutOutput + CheckpointManager. Requires
             enable_hyper_connections=True. Cannot be used with "mlp".
     "gdn_norm_out": recompute the GatedDeltaNet output norm and HP-to-CP all-to-all.
-    "moe_act", "layernorm", "mla_up_proj", "mhc", and "gdn_norm_out" use output-discarding
-    checkpointing, "core_attn", "mlp", "moe", and "shared_experts" use normal checkpointing.
+    "qk_rope": discard-output recompute of the rotary embedding applied to query/key on the
+            split_qkv path (training only). Recompute alone keeps a same-sized tensor (the rope
+            input) instead of the output, so pair it with "qk_rope" in offload_modules to save
+            GPU memory. Mutually exclusive with "core_attn" recompute/offload.
+    "moe_act", "layernorm", "mla_up_proj", "mhc", "gdn_norm_out", and "qk_rope" use
+    output-discarding checkpointing, "core_attn", "mlp", "moe", and "shared_experts" use
+    normal checkpointing.
     """
 
     ####################
@@ -1231,7 +1236,7 @@ class TransformerConfig(ModelParallelConfig):
     offload_modules: Optional[list[str]] = field(default_factory=list)
     """The submodules to offload its input.
     choices: "attn_norm", "qkv_linear", "core_attn", "attn_proj",
-             "mlp_norm", "expert_fc1", "moe_act".
+             "mlp_norm", "expert_fc1", "moe_act", "qk_rope".
     "attn_norm": offload the input of the normalization in the attention part.
     "qkv_linear": offload the input of the qkv linear part.
     "core_attn": offload the input of the core attention part.
@@ -1239,6 +1244,10 @@ class TransformerConfig(ModelParallelConfig):
     "mlp_norm": offload the input of the normalization in the mlp part.
     "expert_fc1": offload the input of the expert fc1 part.
     "moe_act": offload the input of the moe act part.
+    "qk_rope": offload the rope input (post-qk-norm q/k) on the split_qkv path (training
+            only). Only effective when "qk_rope" is also in recompute_modules, whose
+            save_for_backward input is what this group offloads (plain rope does not save
+            its input for backward).
     """
     min_offloaded_tensor_size: int = 1024 * 1024
     """The minimum size of the tensor to be offloaded."""
@@ -1763,6 +1772,7 @@ class TransformerConfig(ModelParallelConfig):
                     "shared_experts",
                     "mhc",
                     "gdn_norm_out",
+                    "qk_rope",
                 }
                 invalid_modules = set(self.recompute_modules) - allowed_modules
                 assert not invalid_modules, (
@@ -1797,6 +1807,37 @@ class TransformerConfig(ModelParallelConfig):
                     "For fused attention, you have no need to set 'core_attn' to recompute. "
                     "Please check that the core_attn recompute is really needed."
                 )
+
+            if "qk_rope" in self.recompute_modules:
+                # qk_rope discard-output recompute releases the rotated q/k after core
+                # attention; core_attn recompute saves those same q/k as its checkpoint
+                # inputs, and core_attn offload offloads the rotated query -- both fight
+                # over the same tensors as qk_rope, so they cannot be combined.
+                if "core_attn" in self.recompute_modules:
+                    raise ValueError(
+                        "qk_rope and core_attn cannot both be in recompute_modules: both "
+                        "target the rotated query/key, so qk_rope's discard would leave "
+                        "core_attn's checkpoint without valid inputs."
+                    )
+                if self.fine_grained_activation_offloading and "core_attn" in self.offload_modules:
+                    raise ValueError(
+                        "qk_rope in recompute_modules is incompatible with core_attn in "
+                        "offload_modules: qk_rope discards the rotated query that core_attn "
+                        "offload tries to move to CPU."
+                    )
+                # Recompute alone keeps a same-sized tensor (the rope input) instead of the
+                # rope output, so it saves no GPU memory unless paired with qk_rope offload.
+                if not (
+                    self.fine_grained_activation_offloading
+                    and "qk_rope" in (self.offload_modules or [])
+                ):
+                    warnings.warn(
+                        "qk_rope is in recompute_modules but not in offload_modules. "
+                        "qk_rope discard-output recompute only saves GPU memory when its "
+                        "save_for_backward input is offloaded (rope input and output are the "
+                        "same size). Add 'qk_rope' to offload_modules with "
+                        "fine_grained_activation_offloading for actual savings."
+                    )
 
             if "shared_experts" in self.recompute_modules:
                 if (
@@ -1918,6 +1959,7 @@ class TransformerConfig(ModelParallelConfig):
                 "attn_norm",
                 "mlp_norm",
                 "qkv_linear",
+                "qk_rope",
             }
             invalid_modules = set(self.offload_modules) - allowed_modules
             assert not invalid_modules, (


### PR DESCRIPTION
# What does this PR do ?

Adds a new **`qk_rope`** module to `recompute_modules` and `offload_modules` that targets the
**rotary position embedding applied to query/key** on the `split_qkv` path (the path that is
active whenever `qk_layernorm` forces `split_qkv=True`, e.g. Qwen3.5-VL).

It exposes the two activation-memory primitives the codebase already uses elsewhere, now over
the q/k rope:

- **`recompute_modules: [qk_rope]`** — discard-output recompute. The rotated q/k (the rope
  *output*, which core attention saves for its backward) are released right after core
  attention via `CheckpointWithoutOutput`, and recomputed in backward through a grad hook on
  `core_attn_out` (whose gradient is produced by the downstream proj/gate backward, i.e. just
  before core attention's backward needs q/k).
- **`offload_modules: [qk_rope]`** — fine-grained activation offload. Offloads the rope
  *input* (post-qk-norm q/k). The input is what `CheckpointWithoutOutput` keeps via
  `save_for_backward`, so the offload group captures it and moves it to CPU.

The two compose by design (the established **discard-output vs offload-input** orthogonality —
`random.py` backward is already written to coexist with CPU offload): offload moves the rope
*input* to CPU, recompute discards the rope *output*; in backward the input is reloaded and the
output recomputed.

### Guards
- `qk_rope` is registered in **both** the `recompute_modules` and `offload_modules`
  allowed-sets.
- `qk_rope` recompute is **mutually exclusive with `core_attn`** recompute/offload — both
  target the same rotated q/k, so combining them would leave one without valid inputs (a hard
  `ValueError`).
- A warning fires if `qk_rope` is in `recompute_modules` but not `offload_modules`: recompute
  *alone* saves nothing because the rope input and output are the same size (it merely swaps
  which same-sized tensor is kept). Pair it with offload for any GPU saving.
- Training-only; inference keeps the inline rope path. Attention runs in normal autograd (not
  the MoE `fine_grained_callables` path), so the grad-hook approach is compatible with A2A
  expert-parallel overlap.

## Files

- `megatron/core/transformer/attention.py` — `recompute_qk_rope`/`offload_qk_rope` flags;
  factored `_apply_qk_rope`; wrap the `split_qkv` rope block with the offload manager +
  `CheckpointWithoutOutput`; discard + register recompute after core attention.
- `megatron/core/transformer/transformer_config.py` — register `qk_rope` in both allowed-sets,
  docstrings, and the guards above.

## Validation

**Functional correctness — confirmed.** Qwen3.5-VL 397B-A17B proxy, 8×GB200 (EP=8, TP=1,
PP=1), `pretrain_multimodal.py`, mbs=4, full mem_stack (`recompute=[layernorm, gdn_norm_out,
moe_act, shared_experts, qk_rope]`, `offload=[expert_fc1, moe_act, attn_norm, mlp_norm,
qk_rope]`) with A2A expert-parallel overlap + delay_wgrad on:

- 20/20 iterations, loss stable ~13.24, grad norm ~5.0, **no NaN / no skipped iters / no
  cuBLAS errors**. The discard-output recompute, offload, and A2A overlap coexist correctly.

**Memory — no peak reduction on this config (honest result).**

| metric | mem_stack baseline | + `qk_rope` (recompute+offload) | Δ |
|---|---|---|---|
| max allocated | 85.9 GB | 86.7 GB | **+0.8 GB** |
| throughput | ~510 TFLOP/s/GPU | ~480–523 | ~flat |

A full memory-event snapshot (`record_memory_history`) shows why: on this model only **3 of 12
layers** are standard SDPA (the rest are GatedDeltaNet), they use **flash attention** (which
never materializes the q/k-derived attention matrix), and the **peak occurs in the backward
pass** (FSDP gradient buckets + offload reloads + GDN recompute), not at the point where the
rope q/k are live. So:

- the rotated q/k are not a peak-driving activation here;
- offloading the rope input does not lower the peak (the peak moment is elsewhere);
- the recompute briefly re-materializes the rotated q/k in backward, nudging the peak up ~0.8 GB.

**When `qk_rope` is expected to help:** models where the q/k rope tensors actually drive the
peak — many SDPA layers, non-flash attention (materializes the score matrix), or large
`head_dim`. The feature is correct and inert when unconfigured; it is offered as a lever for
those configs, not as a win for flash-attention-dominated models like this proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
