### PR TITLE
feat: add attn_qkv selective recompute

### DIFF
--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -242,12 +242,17 @@ class GatedDeltaNet(MegatronModule):
         )
         self.recompute_norm_out = False
         self.recompute_qkv = False
+        self.recompute_core = False
         if self.config.recompute_granularity == "selective":
             self.recompute_norm_out = "gdn_norm_out" in self.config.recompute_modules
             # gdn_qkv: recompute the whole QKV proj+prep block as a discard-output checkpoint.
             self.recompute_qkv = "gdn_qkv" in self.config.recompute_modules
+            # gdn_core: recompute the core chunk gated-delta-rule kernel as a discard-output
+            # checkpoint (discards its chunk_fwd_o / solve_tril / chunk-state intermediates).
+            self.recompute_core = "gdn_core" in self.config.recompute_modules
 
-        # Per-forward CheckpointManager for the GDN discard-output recompute (gdn_qkv/gdn_norm_out).
+        # Per-forward CheckpointManager for the GDN discard-output recompute
+        # (gdn_qkv/gdn_core/gdn_norm_out).
         self.gdn_recompute_manager = None
 
         self.out_proj = build_module(
@@ -366,9 +371,12 @@ class GatedDeltaNet(MegatronModule):
         # QKV output `gate` feeds the gated-norm block, so when both are on the CheckpointManager
         # replays them in forward order (qkv -> norm_out) from one grad hook on `out`.
         recompute_qkv = self.recompute_qkv and self.training
+        recompute_core = self.recompute_core and self.training
         recompute_norm_out = self.recompute_norm_out and self.training
         self.gdn_recompute_manager = (
-            CheckpointManager() if (recompute_qkv or recompute_norm_out) else None
+            CheckpointManager()
+            if (recompute_qkv or recompute_core or recompute_norm_out)
+            else None
         )
 
         # QKV projection + prep block (in_proj -> CP a2a -> conv1d -> _prepare_qkv -> g/beta).
@@ -392,17 +400,33 @@ class GatedDeltaNet(MegatronModule):
         seq_len = value.shape[1]
 
         nvtx_range_push(suffix="gated_delta_rule")
-        core_attn_out, last_recurrent_state = self.gated_delta_rule(
-            query,
-            key,
-            value,
-            g=g,
-            beta=beta,
-            initial_state=None,
-            output_final_state=False,
-            use_qk_l2norm_in_kernel=False,
-            cu_seqlens=cu_seqlens_q,
-        )
+
+        # Core chunk gated-delta-rule. output_final_state=False, so the final recurrent state is
+        # always None; return only core_attn_out so the discard-output checkpoint can resize it.
+        def _core_gated_delta_rule(query, key, value, g, beta):
+            core_attn_out, _ = self.gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=None,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=False,
+                cu_seqlens=cu_seqlens_q,
+            )
+            return core_attn_out
+
+        if recompute_core:
+            # Discard the core output and its internal chunk_fwd_o / solve_tril / chunk-state
+            # intermediates now; regenerate them in backward. The shared CheckpointManager replays
+            # the discard-output checkpoints in forward order (qkv -> core -> norm_out).
+            core_attn_out = tensor_parallel.CheckpointWithoutOutput(
+                fp8=(self.config.fp8 or self.config.fp4),
+                ckpt_manager=self.gdn_recompute_manager,
+            ).checkpoint(_core_gated_delta_rule, query, key, value, g, beta)
+        else:
+            core_attn_out = _core_gated_delta_rule(query, key, value, g, beta)
         nvtx_range_pop(suffix="gated_delta_rule")
 
         def _gated_norm_and_a2a(core_attn_out: torch.Tensor, gate: torch.Tensor):

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -38,6 +38,7 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
 )
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tensor_parallel_region
+from megatron.core.tensor_parallel.random import CheckpointManager
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
@@ -352,6 +353,18 @@ class Attention(MegatronModule, ABC):
             self.config.fine_grained_activation_offloading
             and "qkv_linear" in self.config.offload_modules
         )
+
+        # attn_qkv: recompute the QKV projection + prep as a discard-output checkpoint
+        # (mirrors gdn_qkv). Mutually exclusive with qkv_linear offload (same tensors).
+        self.recompute_qkv = (
+            self.config.recompute_granularity == 'selective'
+            and "attn_qkv" in self.config.recompute_modules
+        )
+        assert not (self.recompute_qkv and self.offload_qkv_linear), (
+            "attn_qkv recompute and qkv_linear offload are mutually exclusive; use only one"
+        )
+        # Per-forward CheckpointManager for the attn_qkv discard-output recompute.
+        self.attn_recompute_manager = None
 
         self.offload_core_attention = (
             self.config.fine_grained_activation_offloading
@@ -1171,17 +1184,36 @@ class Attention(MegatronModule, ABC):
         if head_wise_gate_enabled:
             assert split_qkv, "head_wise_attn_gate is not supported for unsplit mixed_qkv tensor."
 
-        qkv_linear_manager = off_interface(self.offload_qkv_linear, hidden_states, "qkv_linear")
-        with qkv_linear_manager as hidden_states:
-            qkv_output = self.get_query_key_value_tensors(
+        # attn_qkv recompute: only on the split_qkv training path (all-tensor output) and not in
+        # inference. Discards the projected Q/K/V now; regenerates them in backward via the shared
+        # CheckpointManager (recompute hook registered on the attention output before return).
+        recompute_qkv = (
+            self.recompute_qkv and self.training and split_qkv and inference_context is None
+        )
+        self.attn_recompute_manager = CheckpointManager() if recompute_qkv else None
+
+        def _qkv_proj_and_prepare(hidden_states):
+            return self.get_query_key_value_tensors(
                 hidden_states,
                 key_value_states,
                 split_qkv=split_qkv,
                 output_gate=output_gate,
                 head_wise_gate=head_wise_gate_enabled,
             )
-        # `qkv_output` may be a tuple; commit supports tuple/list and will keep structure.
-        qkv_output = qkv_linear_manager.group_offload(qkv_output, forced_released_tensors=[])
+
+        if recompute_qkv:
+            qkv_output = tensor_parallel.CheckpointWithoutOutput(
+                fp8=(self.config.fp8 or self.config.fp4),
+                ckpt_manager=self.attn_recompute_manager,
+            ).checkpoint(_qkv_proj_and_prepare, hidden_states)
+        else:
+            qkv_linear_manager = off_interface(
+                self.offload_qkv_linear, hidden_states, "qkv_linear"
+            )
+            with qkv_linear_manager as hidden_states:
+                qkv_output = _qkv_proj_and_prepare(hidden_states)
+            # `qkv_output` may be a tuple; commit supports tuple/list and will keep structure.
+            qkv_output = qkv_linear_manager.group_offload(qkv_output, forced_released_tensors=[])
         attn_mask_type = self.attn_mask_type
         block_table = None
         gate = None
@@ -1419,6 +1451,12 @@ class Attention(MegatronModule, ABC):
             output, bias = self.linear_proj(core_attn_out)
         output = attn_proj_manager.group_offload(output, forced_released_tensors=[core_attn_out])
         nvtx_range_pop(suffix="linear_proj")
+
+        # attn_qkv recompute: discard the checkpointed Q/K/V (now consumed) and register the unified
+        # recompute hook on the attention output so they are regenerated at the start of backward.
+        if self.attn_recompute_manager is not None:
+            self.attn_recompute_manager.discard_all_outputs_and_register_unified_recompute(output)
+            self.attn_recompute_manager = None
 
         self.pg_collection.cp = _orig_cp_group
         return output, bias

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -546,7 +546,7 @@ class TransformerConfig(ModelParallelConfig):
     recompute_modules: Optional[List[str]] = None
     """The submodules to recompute.
     choices: "core_attn", "moe_act", "layernorm", "mla_up_proj", "mlp", "moe",
-             "shared_experts", "mhc", "gdn_norm_out".
+             "shared_experts", "mhc", "gdn_norm_out", "gdn_qkv", "gdn_core".
     default: ["core_attn"].
     "core_attn": recompute the core attention part of the transformer layer.
     "moe_act": recompute the MoE MLP activation function.
@@ -559,8 +559,15 @@ class TransformerConfig(ModelParallelConfig):
             CheckpointWithoutOutput + CheckpointManager. Requires
             enable_hyper_connections=True. Cannot be used with "mlp".
     "gdn_norm_out": recompute the GatedDeltaNet output norm and HP-to-CP all-to-all.
-    "moe_act", "layernorm", "mla_up_proj", "mhc", and "gdn_norm_out" use output-discarding
-    checkpointing, "core_attn", "mlp", "moe", and "shared_experts" use normal checkpointing.
+    "gdn_qkv": recompute the whole GatedDeltaNet QKV projection + prep block.
+    "gdn_core": recompute the GatedDeltaNet core chunk gated-delta-rule kernel
+            (discards its internal chunk_fwd_o / solve_tril / chunk-state intermediates).
+    "attn_qkv": recompute the standard attention QKV projection + prep (linear_qkv + q/k layernorm)
+            as a discard-output checkpoint. Discards the projected Q/K/V on the device and
+            regenerates them in backward; mutually exclusive with "qkv_linear" offload.
+    "moe_act", "layernorm", "mla_up_proj", "mhc", "gdn_norm_out", "gdn_qkv", "gdn_core", and
+    "attn_qkv" use output-discarding checkpointing, "core_attn", "mlp", "moe", and "shared_experts"
+    use normal checkpointing.
     """
 
     ####################
@@ -1782,6 +1789,8 @@ class TransformerConfig(ModelParallelConfig):
                     "mhc",
                     "gdn_norm_out",
                     "gdn_qkv",
+                    "gdn_core",
+                    "attn_qkv",
                 }
                 invalid_modules = set(self.recompute_modules) - allowed_modules
                 assert not invalid_modules, (
@@ -1815,6 +1824,15 @@ class TransformerConfig(ModelParallelConfig):
             ):
                 raise ValueError(
                     "gdn_qkv in recompute_modules is only supported with "
+                    "experimental_attention_variant='gated_delta_net'."
+                )
+
+            if (
+                "gdn_core" in self.recompute_modules
+                and self.experimental_attention_variant != "gated_delta_net"
+            ):
+                raise ValueError(
+                    "gdn_core in recompute_modules is only supported with "
                     "experimental_attention_variant='gated_delta_net'."
                 )
 


### PR DESCRIPTION
## Summary
Adds **`attn_qkv`** to `recompute_modules` (selective recompute): a discard-output checkpoint wrapping the standard attention QKV projection + prep (`linear_qkv` + q/k layernorm) in `Attention.forward`, mirroring the existing `gdn_qkv` path.

When `"attn_qkv"` is in `recompute_modules`, the projected Q/K/V are discarded on device after the forward and regenerated in backward via a per-forward `CheckpointManager`; the unified recompute hook is registered on the attention output. Reduces GPU activation memory at **zero host cost** (unlike offloading `qkv_linear`).

### Changes
- `transformer_config.py`: add `"attn_qkv"` to the allowed `recompute_modules` set + docstring.
- `attention.py`: add `self.recompute_qkv` flag (selective + `"attn_qkv"`), assert mutual exclusion with `qkv_linear` offload, wrap `get_query_key_value_tensors` in `CheckpointWithoutOutput` and register the recompute hook on the output.

### Notes
- Only active on the **split_qkv training path** (all-tensor output); inference / non-split fall back to the normal path.
- **Mutually exclusive** with `qkv_linear` fine-grained offload (same tensors).
- This branch also carries **`gdn_core`** (recompute the GatedDeltaNet core chunk gated-delta-rule kernel) so the full selective-recompute stack lands on the `gdn-conv-fusion-and-opt` base together.

## Test plan
fake-pg 397B (EP64, mbs4, offload-2 = expert_fc1+moe_act, max selective recompute), A/B on aws-dfw:

| | A (no attn_qkv) | B (+attn_qkv) | Δ |
|---|--:|--:|--:|
| peak GPU device-used (iter2) | 164.8 GB | 156.0 GB | **-8.8 GB** |
| max_allocated | 154.0 GB | 144.1 GB | -9.6 GB |
| host | 232 GB | 232 GB | 0 (recompute, no host) |

No errors, loss unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)